### PR TITLE
Expose linked definitions

### DIFF
--- a/apis/cds.d.ts
+++ b/apis/cds.d.ts
@@ -1,6 +1,7 @@
 export * from './core'
 export * from './server'
 export * from './env'
+export * from './linked'
 export * from './models'
 export * from './services'
 export * from './events'


### PR DESCRIPTION
In our project we use the linked definitions which are currently not exposed. 
This pull request should fix that