### PR TITLE
Introduce `UnionToIntersection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - Type for special error listener `srv.on('error')`
 
+### Changed
+
+- `source`, `column_expr`, and `predicate` have been converted to partial intersection types. This offers all possible optional properties. You will have to make sure to check their presence when accessing them
+
 ### Fixed
 
 - `srv.send` overload to also allow optional headers
@@ -19,7 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
-- Rework of the export structure of the main `cds` facade object, so that e.g. `cds.Request` and `cds.User` work again.
+- Rework of the export structure of the main `cds` facade object, so that e.g. `cds.Request` and `cds.User` work again
 
 ### Fixed
 

--- a/apis/cqn.d.ts
+++ b/apis/cqn.d.ts
@@ -1,4 +1,5 @@
 import { entity } from './csn' // cyclic dependency
+import { UnionToIntersection, UnionsToIntersections } from './internal/inference'
 
 // FIXME: a union type would be more appropriate here
 export type Query = Partial<SELECT & INSERT & UPDATE & DELETE & CREATE & DROP & UPSERT>
@@ -66,9 +67,9 @@ type data = Record<string, any>
 type name = string
 
 /** @private */
-type source = (ref | SELECT) & { as?: name, join?: name, on?: xpr }
-export type column_expr = expr & { as?: name, cast?: any, expand?: column_expr[], inline?: column_expr[] }
-export type predicate = _xpr
+type source = UnionToIntersection<ref | SELECT> & { as?: name, join?: name, on?: xpr }
+export type column_expr = UnionToIntersection<expr> & { as?: name, cast?: any, expand?: column_expr[], inline?: column_expr[] }
+export type predicate = UnionsToIntersections<_xpr>
 
 /** @private */
 type ordering_term = expr & { sort?: 'asc' | 'desc', nulls?: 'first' | 'last' }


### PR DESCRIPTION
This PR introduces some utility types that convert a union into an intersection type.
The idea is to work around having to manually convert/ duplicate union types in situations where we lack a more specific generic parameter[^1]. For example, using

```ts
export type expr = ref | val | xpr | function_call | SELECT
```

as return type in a function gives the user no code completion at all, as the types do not overlap and TS can not infer any properties that would be present regardless of which subtype is actually used.

```ts
function f (): expr { ... }
const x = f()
x.  // no code completion
```

We can work around this by using

```ts
export type expr = ref & val & xpr & function_call & SELECT
```

instead, which will offer _all_ properties of _all_ subtypes, regardless of the actual subtype. By further changing it to

```ts
export type expr = Partial<ref & val & xpr & function_call & SELECT>
```

all properties are present, but [declared as optional](https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype). So users are at least made aware that they should make sure the property really is present.

Now instead of actually touching all of our unions and converting them manually, the introduced utility types perform this conversion in place.

```ts
function f (): UnionToIntersection<expr> { ... }
const x = f()
x.  // code completion and expr remains untouched
```

Having these utility types also serves us as marker of where types are currently incorrect. If we manually rewrote them we might be led to believe the type is actually supposed to be an intersection during rewrites. Seeing the wrapper makes it clear we have to stricten the types where they are being used currently.

[^1]: see this [playground](https://www.typescriptlang.org/play?#code/AQKGwFwTwBwU2AQWAXmAb2AQwFzAHYCuAtgEZwBOwAvmJLAgEKobCl4DOEFAlvgOY060eMABiAewktkAH2CM6AM0L4AxhB4T8wJQAoAlHknTMFOBEIUdqgCZwlfOLewdgqgNb4JAdx1Y3EyFwNW0uYAAPFn0DOgiAOixwAHpk4EoKCQoAGmBQwgAbFywCjmlyYC5eATplVQ0tHX4AHgAVdIiIOHxbQKkAPkM8drMLKxsehydit09vP1dgdtoQsIhgKBYWxEHY8ChEoA) for an example how it should look like instead.