### PR TITLE
Import `@sap/cds` in tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Run Unit Tests
       run: |
         npm install
+        npm install file:. --no-save --force
         npm run test
 
     - name: get-version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,16 @@ The following rule governs code contributions:
 * Contributions must be licensed under the [Apache 2.0 License](./LICENSE)
 * Due to legal reasons, contributors will be asked to accept a Developer Certificate of Origin (DCO) when they create the first pull request to this project. This happens in an automated fashion during the submission process. SAP uses [the standard DCO text of the Linux Foundation](https://developercertificate.org/).
 
+### Local Setup
+
+After cloning, just run
+
+```sh
+npm run setup
+```
+
+which installs all dependencies.
+
 ## Issues and Planning
 
 * We use GitHub issues to track bugs and enhancement requests.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,18 @@ Find more information on the APIs in the [Node.js SDK documentation](https://cap
 
 ## Support, Feedback, Contributing
 
+### Local Setup
+
+After cloning, just run
+
+```sh
+npm run setup
+```
+
+which installs all dependencies.
+
 This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://github.com/cap-js/cds-types/issues). Contribution and feedback are encouraged and always welcome. For more information about how to contribute, the project structure, as well as additional contribution information, see our [Contribution Guidelines](CONTRIBUTING.md).
+
 
 ## Security / Disclosure
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@sap/cds": ">=7"
   },
   "devDependencies": {
-    "@sap/cds": "^7.4.0",
+    "@sap/cds": "^7.5.0",
     "@stylistic/eslint-plugin": "^1.5.3",
     "@types/jest": "^29.5.11",
     "@types/node": "^20",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test": "jest --silent",
     "api-extractor": "api-extractor run --local --verbose",
     "lint": "eslint . --ext .ts",
-    "lint:fix": "eslint . --ext .ts --fix"
+    "lint:fix": "eslint . --ext .ts --fix",
+    "setup": "npm i && npm i file:. --no-save --force"
   },
   "peerDependencies": {
     "@sap/cds": ">=7"

--- a/test/typescript/apis/project/cds-core.ts
+++ b/test/typescript/apis/project/cds-core.ts
@@ -1,4 +1,4 @@
-import cds from '../../../../apis/cds'
+import cds from '@sap/cds'
 
 const x = cds.extend({ a: 42 }).with({ b: 'hello world' })
 const a: number = x.a

--- a/test/typescript/apis/project/cds-cqn.ts
+++ b/test/typescript/apis/project/cds-cqn.ts
@@ -1,11 +1,11 @@
-import * as cqn from "../../../../apis/cqn";
+import cds from '@sap/cds'
 
 // we just access expected properties without doing anything with them to see if they are present
 // as expected. To apease the linter, we assign them to a variable.
 let res = undefined
 
 // CQN
-const sqn: cqn.SELECT = {SELECT:{from:{ ref:[ 'Foo' ]}}}
+const sqn: cds.SELECT = {SELECT:{from:{ ref:[ 'Foo' ]}}}
 // order by
 sqn.SELECT.orderBy = [{ ref: ["bar"], sort: "desc" }]
 sqn.SELECT.orderBy = [{ ref: ["bar"], sort: "asc" }]
@@ -26,14 +26,13 @@ res = sqn.SELECT.limit
 res = sqn.SELECT.mixin
 
 // Runtime only...
-import cds from "../../../../apis/cds";
 let q = SELECT.from('Foo')
 res = q.SELECT.forUpdate
 res = q.SELECT.forShareLock
 res = q.SELECT.search
 res = q.SELECT.count
 
-const iqn: cqn.INSERT = undefined as unknown as cqn.INSERT
+const iqn: cds.INSERT = undefined as unknown as cds.INSERT
 res = iqn.INSERT.into.hasOwnProperty('ref') || (typeof iqn.INSERT.into === 'string')
 res = iqn.INSERT.columns
 res = iqn.INSERT.values
@@ -41,20 +40,20 @@ res = iqn.INSERT.rows
 res = iqn.INSERT.entries
 res = iqn.INSERT.as.SELECT
 
-const uqn: cqn.UPDATE = undefined as unknown as cqn.UPDATE
+const uqn: cds.UPDATE = undefined as unknown as cds.UPDATE
 res = uqn.UPDATE.data['foo']
 // res = uqn.UPDATE.entity.toLowerCase()  // lazy "type check" for string
 res = uqn.UPDATE.where?.at(0)
 
-const dqn: cqn.DELETE = undefined as unknown as cqn.DELETE
+const dqn: cds.DELETE = undefined as unknown as cds.DELETE
 // res = dqn.DELETE.from.toLowerCase()  // lazy "type check" for string
 res = dqn.DELETE.where?.at(0)
 
-const crqn: cqn.CREATE = undefined as unknown as cqn.CREATE
+const crqn: cds.CREATE = undefined as unknown as cds.CREATE
 res = crqn.CREATE.entity.hasOwnProperty('ref') || (typeof crqn.CREATE.entity === 'string')  // lazy "type check" for string
 res = crqn.CREATE.as.SELECT
 
-const drqn: cqn.DROP = undefined as unknown as cqn.DROP
+const drqn: cds.DROP = undefined as unknown as cds.DROP
 res = drqn.DROP.entity.toLowerCase()  // lazy "type check" for string
 res = drqn.DROP.table.ref
 res = drqn.DROP.view.ref

--- a/test/typescript/apis/project/cds-exit.ts
+++ b/test/typescript/apis/project/cds-exit.ts
@@ -1,3 +1,3 @@
-import cds from '../../../../apis/cds'
+import cds from '@sap/cds'
 
 cds.exit()

--- a/test/typescript/apis/project/cds-log.ts
+++ b/test/typescript/apis/project/cds-log.ts
@@ -1,4 +1,4 @@
-import cds from '../../../..'
+import cds from '@sap/cds'
 import * as winston from "winston"
 
 cds.log('foo').debug('message')

--- a/test/typescript/apis/project/cds-services.ts
+++ b/test/typescript/apis/project/cds-services.ts
@@ -1,4 +1,4 @@
-import cds from '../../../..'
+import cds from '@sap/cds'
 import { Foo, Foos, action } from './dummy'
 
 const model = cds.reflect({})

--- a/test/typescript/apis/project/cds-test.ts
+++ b/test/typescript/apis/project/cds-test.ts
@@ -1,4 +1,4 @@
-import cds from '../../../..'
+import cds from '@sap/cds'
 
 const test = cds.test(__dirname).in('other')
 cds.test('serve', '--in-memory', '--project', __dirname)

--- a/test/typescript/apis/project/cds-user.ts
+++ b/test/typescript/apis/project/cds-user.ts
@@ -1,5 +1,4 @@
-import cds from '../../../..'
-import { User } from '../../../../apis/cds'
+import cds, { User } from '@sap/cds'
 
 // accepts no args
 const user = new User()

--- a/test/typescript/apis/project/cds-utils.ts
+++ b/test/typescript/apis/project/cds-utils.ts
@@ -1,4 +1,4 @@
-import cds from '../../../..'
+import cds from '@sap/cds'
 
 const uuid: string = cds.utils.uuid()
 const decodeURI: string = cds.utils.decodeURI('https://developer.mozilla.org/docs/JavaScript%3A%20a_scripting_language')

--- a/test/typescript/apis/project/legacy.ts
+++ b/test/typescript/apis/project/legacy.ts
@@ -29,17 +29,16 @@ import {
   Service,
 } from "@sap/cds/apis/services";
 
-// --- works again with sap/cds >= 7.5
-// import {
-//   Definition as DefinitionRefl,
-//   entity as entityRefl,
-//   LinkedModel,
-//   LinkedDefinition as LinkedDefinitionRefl,
-//   ParsedModel,
-//   ReflectedModel,
-//   ReflectedDefinitions,
-// } from "@sap/cds/apis/reflect";
+import {
+  Definition as DefinitionRefl,
+  entity as entityRefl,
+  LinkedModel,
+  LinkedDefinition as LinkedDefinitionRefl,
+  ParsedModel,
+  ReflectedModel,
+  ReflectedDefinitions,
+} from "@sap/cds/apis/reflect";
 
-// import { Definitions } from '@sap/cds/apis/csn'
-// import { User as CoreUser } from '@sap/cds/apis/core'
-// import { Logger } from '@sap/cds/apis/log'
+import { Definitions } from '@sap/cds/apis/csn'
+import { User as CoreUser } from '@sap/cds/apis/core'
+import { Logger } from '@sap/cds/apis/log'


### PR DESCRIPTION
This reflect the import pattern in reality more than the previous import of the `cds.d.ts` file.

Also: enable tests for the 7.5 legacy facade from `@sap/cds`.