### PR TITLE
Reorder overloads to give plural precedence over singular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## Version 0.3.0 - tbd
 
 ### Added
+- Added signatures for `cds.outboxed` and `cds.unboxed`
 
 ### Changed
 - `Service.prepend` is no longer async.

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -120,8 +120,8 @@ export type StaticSELECT<T> = typeof SELECT
   & ((...columns: string[]) => SELECT<T>)
   & ((columns: string[]) => SELECT<T>)
   & (TaggedTemplateQueryPart<SELECT<T>>)
-  & SELECT_one // as it is not directly quantified, ...
-  & SELECT_from // ...we should expect both a scalar and a list
+  & SELECT_from // as it is not directly quantified, ...
+  & SELECT_one // ...we should expect both a scalar and a list
 
 declare class QL<T> {
 

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -18,6 +18,8 @@ s.SELECT.columns?.[0].ref
 s.SELECT.where?.[0].ref
 s.SELECT.where?.[2].val
 
+SELECT(Foos) === SELECT.from(Foos)
+
 INSERT.into(Foos).columns("x") // x was suggested by code completion
 let ins: INSERT<Foo>
 ins = INSERT.into(Foos, {})


### PR DESCRIPTION
It was reported that static selects and ones triggered with `.from` would behave slightly differently

```ts
SELECT(Books) → SELECT.from(Books)
```

This was caused by the ordering of overloads which would try to handle singulars before plurals. By reordering, we check if the passed type is an array _first_, and only _then_ try to treat it as singular.