### PR TITLE
Allow log level labels as label parameter

### DIFF
--- a/apis/log.d.ts
+++ b/apis/log.d.ts
@@ -47,7 +47,7 @@ declare type LogFactory = {
      * @returns the logger
      * @see [capire](https://cap.cloud.sap/docs/node.js/cds-log)
      */
-  (name: string, options?: string | number | { level?: number, label?: string, prefix?: string }): Logger,
+  (name: string, options?: string | number | { level?: LogLevel, label?: string, prefix?: string }): Logger,
 
   /**
      * Set a custom formatter function like that:
@@ -167,7 +167,9 @@ declare type Log = {
 }
 
 declare enum levels {
-  // FIXME: check if this is a copy-paste error
+  // SILLY and VERBOSE are aliases for TRACE
   /* eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values */
   SILENT = 0, ERROR = 1, WARN = 2, INFO = 3, DEBUG = 4, TRACE = 5, SILLY = 5, VERBOSE = 5
 }
+
+type LogLevel = keyof typeof levels | Lowercase<keyof typeof levels> | levels


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-types/issues/30

Allows valid log levels, as well as names of said levels (upper and lower case) as parameter:

![Screenshot 2024-02-05 at 03 42 48](https://github.com/cap-js/cds-types/assets/103028279/5e1019ac-c80c-400f-bb39-404123e2d0e9)

@johannes-vogel 

There is also:

```ts
declare type Formatter = {
  /**
     * Custom format function
     *
     * @param module - logger name
     * @param level - log level
     * @param args - additional arguments
     * @returns an array of arguments, which are passed to the logger (for example, `console.log()`)
     */
  (module: string, level: number, args: any[]): any[],
}
```

should this `level` parameter receive the same treatment?