### PR TITLE
Fix/select-from-drafts

### DIFF
--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -258,6 +258,13 @@ type SELECT_from =
   & (<T> (entity: T[], projection?: Projection<T>) => SELECT<T> & Promise<T[]>)
   & (<T> (entity: T[], primaryKey: PK, projection?: Projection<T>) => Awaitable<SELECT<T>, T>)
   & ((subject: ref) => SELECT<any>)
+// put these overloads at the very end, as they would also match the above
+  & (<T extends Constructable<any>>
+  (entityType: T, projection?: Projection<InstanceType<T>>)
+  => Awaitable<SELECT<InstanceType<T>>, InstanceType<T>>)
+  & (<T extends Constructable<any>>
+  (entityType: T, primaryKey: PK, projection?: Projection<InstanceType<T>>)
+  => Awaitable<SELECT<InstanceType<T>>, InstanceType<T>>)
 
 export class INSERT<T> extends ConstructedQuery {
 

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -4,10 +4,12 @@ import { Foo, Foos, attach } from './dummy'
 // unwrapped plural types
 let sel: SELECT<Foo>
 sel = SELECT(Foo)
+sel = SELECT(Foo, 42)
 sel = SELECT(Foo.drafts)
 sel = SELECT(Foos.drafts)
 sel = SELECT.from(Foo.drafts)
 sel = SELECT.from(Foos.drafts)
+sel = SELECT.from(Foos.drafts, 42)
 
 const selStatic: SELECT<Foos> | Promise<Foos> = SELECT.from(Foos)
 

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -4,6 +4,11 @@ import { Foo, Foos, attach } from './dummy'
 // unwrapped plural types
 let sel: SELECT<Foo>
 sel = SELECT(Foo)
+sel = SELECT(Foo.drafts)
+sel = SELECT(Foos.drafts)
+sel = SELECT.from(Foo.drafts)
+sel = SELECT.from(Foos.drafts)
+
 const selStatic: SELECT<Foos> | Promise<Foos> = SELECT.from(Foos)
 
 SELECT.from(Foos).columns("x") // x was suggested by code completion

--- a/test/typescript/apis/project/dummy.ts
+++ b/test/typescript/apis/project/dummy.ts
@@ -5,13 +5,13 @@ import { Subqueryable } from '../../../../apis/ql'
 
 // dummies to test singular and plural types in queries with
 export class Foo {
-    static drafts = []
+    static readonly drafts: typeof Foo
     x: number = 42
     ref?: Foo
     refs?: Foo[]
   }
 
-export class Foos extends Array<Foo> {}
+export class Foos extends Array<Foo> { static readonly drafts: typeof Foo }
 
 
 // for bound/ unbound actions


### PR DESCRIPTION
Allows the use of `SELECT.from(Books.drafts)` et al.