### PR TITLE
Use plural form in `SELECT.from` in combination with `.drafts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - `Service.prepend` is no longer async.
 
 ### Fixed
-- `SELECT.from` and related variants now work on the `.drafts` property
+- `SELECT.from` and related variants now work on the `.drafts` property and behave like `SELECT.from(<Plural>)`
 - `cds.log` can now also be called with the names of log levels
 
 

--- a/apis/internal/inference.d.ts
+++ b/apis/internal/inference.d.ts
@@ -18,6 +18,8 @@ export interface ArrayConstructable<T = any> {
 // `SingularType<typeof Books>` == `Book`.
 export type SingularType<T extends ArrayConstructable<T>> = InstanceType<T>[number]
 
+export type PluralType<T extends Constructable> = Array<InstanceType<T>>
+
 // Convenient way of unwrapping the inner type from array-typed values, as well as the value type itself
 // `class MyArray<T> extends Array<T>``
 // The latter is used heavily in the CDS typer, but its behaviour depends based on how the types are imported:

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -1,6 +1,6 @@
 import { Definition, EntityElements } from './csn'
 import * as CQN from './cqn'
-import { Constructable, ArrayConstructable, SingularType } from './internal/inference'
+import { Constructable, ArrayConstructable, SingularType, PluralType } from './internal/inference'
 import { LinkedEntity } from './linked'
 import { ref, column_expr } from './cqn'
 
@@ -258,13 +258,17 @@ type SELECT_from =
   & (<T> (entity: T[], projection?: Projection<T>) => SELECT<T> & Promise<T[]>)
   & (<T> (entity: T[], primaryKey: PK, projection?: Projection<T>) => Awaitable<SELECT<T>, T>)
   & ((subject: ref) => SELECT<any>)
-// put these overloads at the very end, as they would also match the above
-  & (<T extends Constructable<any>>
-  (entityType: T, projection?: Projection<InstanceType<T>>)
-  => Awaitable<SELECT<InstanceType<T>>, InstanceType<T>>)
-  & (<T extends Constructable<any>>
-  (entityType: T, primaryKey: PK, projection?: Projection<InstanceType<T>>)
-  => Awaitable<SELECT<InstanceType<T>>, InstanceType<T>>)
+  // put these overloads at the very end, as they would also match the above
+  // We expect these to be the overloads for scalars since we covered arrays above -> wrap them back in Array
+  & (<T extends Constructable<any>>(
+    entityType: T,
+    projection?: Projection<InstanceType<T>>
+  ) => Awaitable<SELECT<PluralType<T>>, PluralType<T>>)
+  & (<T extends Constructable<any>>(
+    entityType: T,
+    primaryKey: PK,
+    projection?: Projection<InstanceType<T>>
+  ) => Awaitable<SELECT<PluralType<T>>, PluralType<T>>);
 
 export class INSERT<T> extends ConstructedQuery {
 

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -268,7 +268,7 @@ type SELECT_from =
     entityType: T,
     primaryKey: PK,
     projection?: Projection<InstanceType<T>>
-  ) => Awaitable<SELECT<PluralType<T>>, PluralType<T>>);
+  ) => Awaitable<SELECT<PluralType<T>>, PluralType<T>>)
 
 export class INSERT<T> extends ConstructedQuery {
 

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -2,7 +2,7 @@ import { QLExtensions } from '../../../../apis/ql'
 import { Foo, Foos, attach } from './dummy'
 
 // unwrapped plural types
-let sel: SELECT<Foo>
+let sel: SELECT<Foos>
 sel = SELECT(Foo)
 sel = SELECT(Foo, 42)
 sel = SELECT(Foo.drafts)


### PR DESCRIPTION
Using `SELECT.from(Books.drafts)` would type the result to be a single `Book`. With this change it is expected to be an array instead.