### PR TITLE
Streamline handlers for classes to plural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - All linked classes are now available via `cds.linked.classes` (and partially via the facade)
 - Getters in `service` instances now return the appropriate classes. E.g. `service.entities` returns instances of `linked.entity`
 - [breaking] Linked definitions are no longer an intersection type of all possible linked classes, but more specific to their actual use (see above). This implies that users may have to narrow the type they are using explicitly, use another getter (see above), or use explicit casts.
+- [breaking] Only the `.after('READ', ...)` differentiates between singular and plural entities. In all other cases the plural case is assumed.
 
 ### Fixed
 - `SELECT.from` and related variants now work on the `.drafts` property and behave like `SELECT.from(<Plural>)`

--- a/apis/services.d.ts
+++ b/apis/services.d.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { SELECT, INSERT, UPDATE, DELETE, Query, ConstructedQuery, UPSERT } from './ql'
 import { Awaitable } from './ql'
-import { ArrayConstructable, Constructable } from './internal/inference'
+import { ArrayConstructable, Constructable, Unwrap } from './internal/inference'
 import { ModelPart, LinkedCSN, LinkedDefinition, LinkedEntity } from './linked'
 import * as linked from './linked/classes'
 import { CSN } from './csn'
@@ -225,8 +225,8 @@ export class Service extends QueryAPI {
   // Provider API
   prepend (fn: ServiceImpl): this
 
-  on<T extends ArrayConstructable>(eve: types.event, entity: T, handler: CRUDEventHandler.On<InstanceType<T>, InstanceType<T> | void | Error>): this
-  on<T extends Constructable>(eve: types.event, entity: T, handler: CRUDEventHandler.On<Array<InstanceType<T>>, Array<InstanceType<T>> | void | Error>): this
+  on<T extends ArrayConstructable>(eve: types.event, entity: T, handler: CRUDEventHandler.On<InstanceType<T>>): this
+  on<T extends Constructable>(eve: types.event, entity: T, handler: CRUDEventHandler.On<Array<InstanceType<T>>>): this
   on<F extends CdsFunction>(boundAction: F, service: string, handler: ActionEventHandler<F['__parameters'], void | Error | F['__returns']>): this
   on<F extends CdsFunction>(unboundAction: F, handler: ActionEventHandler<F['__parameters'], void | Error | F['__returns']>): this
   on (eve: types.event, entity: types.target, handler: OnEventHandler): this
@@ -237,8 +237,8 @@ export class Service extends QueryAPI {
   // onSucceeded (eve: types.Events, handler: types.EventHandler): this
   // onFailed (eve: types.Events, entity: types.Target, handler: types.EventHandler): this
   // onFailed (eve: types.Events, handler: types.EventHandler): this
-  before<T extends ArrayConstructable>(eve: types.event, entity: T, handler: CRUDEventHandler.Before<InstanceType<T>, InstanceType<T> | void | Error>): this
-  before<T extends Constructable>(eve: types.event, entity: T, handler: CRUDEventHandler.Before<Array<InstanceType<T>>, Array<InstanceType<T>> | void | Error>): this
+  before<T extends ArrayConstructable>(eve: types.event, entity: T, handler: CRUDEventHandler.Before<InstanceType<T>>): this
+  before<T extends Constructable>(eve: types.event, entity: T, handler: CRUDEventHandler.Before<Array<InstanceType<T>>>): this
   before (eve: types.event, entity: types.target, handler: EventHandler): this
   before (eve: types.event, handler: EventHandler): this
 
@@ -247,9 +247,10 @@ export class Service extends QueryAPI {
   // (3) check if T is scalar -> wrap into array
   // this streamlines that in _most_ cases, handlers will receive an array.
   // _Except_ for after.read handlers (1), which will change its inflection based on T.
-  after<T extends Constructable>(event: 'READ', entity: T, handler: CRUDEventHandler.After<InstanceType<T>, InstanceType<T> | void | Error>): this
-  after<T extends ArrayConstructable>(eve: types.event, entity: T, handler: CRUDEventHandler.After<InstanceType<T>, InstanceType<T> | void | Error>): this
-  after<T extends Constructable>(eve: types.event, entity: T, handler: CRUDEventHandler.After<Array<InstanceType<T>>, Array<InstanceType<T>> | void | Error>): this
+  after<T extends ArrayConstructable>(event: 'READ' | 'EACH', entity: T, handler: CRUDEventHandler.After<Unwrap<T>>): this
+  after<T extends Constructable>(event: 'READ' | 'EACH', entity: T, handler: CRUDEventHandler.After<InstanceType<T>>): this
+  after<T extends ArrayConstructable>(eve: types.event, entity: T, handler: CRUDEventHandler.After<InstanceType<T>>): this
+  after<T extends Constructable>(eve: types.event, entity: T, handler: CRUDEventHandler.After<Array<InstanceType<T>>>): this
   after (eve: types.event, entity: types.target, handler: ResultsHandler): this
   after (eve: types.event, handler: ResultsHandler): this
 
@@ -348,9 +349,9 @@ type TypedRequest<T> = Omit<Request, 'data'> & { data: T }
 
 // https://cap.cloud.sap/docs/node.js/core-services#srv-on-before-after
 declare namespace CRUDEventHandler {
-  type Before<P, R> = (req: TypedRequest<P>) => Promise<R> | R
-  type On<P, R> = (req: TypedRequest<P>, next: (...args: any[]) => Promise<R> | R) => Promise<R> | R
-  type After<P, R> = (data: undefined | P, req: TypedRequest<P>) => Promise<R> | R
+  type Before<P, R = P | void | Error> = (req: TypedRequest<P>) => Promise<R> | R
+  type On<P, R = P | void | Error> = (req: TypedRequest<P>, next: (...args: any[]) => Promise<R> | R) => Promise<R> | R
+  type After<P, R = P | void | Error> = (data: undefined | P, req: TypedRequest<P>) => Promise<R> | R
 }
 
 // Handlers for actions try to infer the passed .data property

--- a/apis/services.d.ts
+++ b/apis/services.d.ts
@@ -225,33 +225,32 @@ export class Service extends QueryAPI {
   // Provider API
   prepend (fn: ServiceImpl): this
 
-  on<T extends Constructable>(eve: types.event, entity: T, handler: CRUDEventHandler.On<InstanceType<T>, InstanceType<T> | void | Error>): this
-
+  on<T extends ArrayConstructable>(eve: types.event, entity: T, handler: CRUDEventHandler.On<InstanceType<T>, InstanceType<T> | void | Error>): this
+  on<T extends Constructable>(eve: types.event, entity: T, handler: CRUDEventHandler.On<Array<InstanceType<T>>, Array<InstanceType<T>> | void | Error>): this
   on<F extends CdsFunction>(boundAction: F, service: string, handler: ActionEventHandler<F['__parameters'], void | Error | F['__returns']>): this
-
   on<F extends CdsFunction>(unboundAction: F, handler: ActionEventHandler<F['__parameters'], void | Error | F['__returns']>): this
-
   on (eve: types.event, entity: types.target, handler: OnEventHandler): this
-
   on (eve: types.event, handler: OnEventHandler): this
-
   on (eve: 'error', handler: OnErrorHandler): this
-
 
   // onSucceeded (eve: types.Events, entity: types.Target, handler: types.EventHandler): this
   // onSucceeded (eve: types.Events, handler: types.EventHandler): this
   // onFailed (eve: types.Events, entity: types.Target, handler: types.EventHandler): this
   // onFailed (eve: types.Events, handler: types.EventHandler): this
-  before<T extends Constructable>(eve: types.event, entity: T, handler: CRUDEventHandler.Before<InstanceType<T>, InstanceType<T> | void | Error>): this
-
+  before<T extends ArrayConstructable>(eve: types.event, entity: T, handler: CRUDEventHandler.Before<InstanceType<T>, InstanceType<T> | void | Error>): this
+  before<T extends Constructable>(eve: types.event, entity: T, handler: CRUDEventHandler.Before<Array<InstanceType<T>>, Array<InstanceType<T>> | void | Error>): this
   before (eve: types.event, entity: types.target, handler: EventHandler): this
-
   before (eve: types.event, handler: EventHandler): this
 
-  after<T extends Constructable>(eve: types.event, entity: T, handler: CRUDEventHandler.After<InstanceType<T>, InstanceType<T> | void | Error>): this
-
+  // order relevant:
+  // (2) check if T is arrayable -> use T directly
+  // (3) check if T is scalar -> wrap into array
+  // this streamlines that in _most_ cases, handlers will receive an array.
+  // _Except_ for after.read handlers (1), which will change its inflection based on T.
+  after<T extends Constructable>(event: 'READ', entity: T, handler: CRUDEventHandler.After<InstanceType<T>, InstanceType<T> | void | Error>): this
+  after<T extends ArrayConstructable>(eve: types.event, entity: T, handler: CRUDEventHandler.After<InstanceType<T>, InstanceType<T> | void | Error>): this
+  after<T extends Constructable>(eve: types.event, entity: T, handler: CRUDEventHandler.After<Array<InstanceType<T>>, Array<InstanceType<T>> | void | Error>): this
   after (eve: types.event, entity: types.target, handler: ResultsHandler): this
-
   after (eve: types.event, handler: ResultsHandler): this
 
   reject (eves: types.event, ...entity: types.target[]): this
@@ -262,20 +261,14 @@ export class ApplicationService extends Service {}
 export class MessagingService extends Service {}
 export class RemoteService extends Service {}
 export class DatabaseService extends Service {
-
   deploy (model?: CSN | string): Promise<CSN>
-
   begin (): Promise<void>
-
   commit (): Promise<void>
-
   rollback (): Promise<void>
-
 }
 
 
 export default class cds {
-
 
   /**
    * @see [capire docs](https://cap.cloud.sap/docs/node.js/core-services)

--- a/test/typescript/apis/project/cds-services.ts
+++ b/test/typescript/apis/project/cds-services.ts
@@ -208,7 +208,10 @@ srv.on('READ', Foos, (req, next) => { isMany(req); return next() })
 srv.before('READ', Foo, req => { isMany(req); return req.data })
 srv.before('READ', Foos, req => isMany(req))
 srv.after('READ', Foo, (data) => { isOne(data); return data })
-srv.after('READ', Foos, (data) => isMany(data))
+srv.after('READ', Foos, (data) => isOne(data))
+
+srv.after('EACH', Foo, (data) => { isOne(data); return data })
+srv.after('EACH', Foos, (data) => isOne(data))
 
 srv.on('UPDATE', Foo, (req, next) => { isMany(req); return next() })
 srv.on('UPDATE', Foos, (req, next) => { isMany(req); return next() })

--- a/test/typescript/apis/project/cds-services.ts
+++ b/test/typescript/apis/project/cds-services.ts
@@ -1,4 +1,4 @@
-import cds from '@sap/cds'
+import cds, { TypedRequest } from '@sap/cds'
 import { Foo, Foos, action } from './dummy'
 const model = cds.reflect({})
 const { Book: Books } = model.entities
@@ -186,18 +186,44 @@ srv.on('error', (err, req) => {
   req.event
 })
 
+
+function isOne(p: TypedRequest<Foo> | Foo | undefined ) { if(!p) return; p instanceof Foo ? p.x.toFixed : p.data.x.toFixed}
+function isMany(p: TypedRequest<Foos> | Foos | undefined) { if(!p) return; p instanceof Foos ? p[0].x.toFixed : p.data[0].x.toFixed}
+
 // Typed bound/ unbound actions
 // The handler must return a number to be in line with action's signature (or void)
 srv.on(action, req => req.data.foo.x)
 srv.on(action, 'FooService', req => req.data.foo.x)
 
+srv.on('CREATE', Foo, (req, next) => { isMany(req); return next() })
+srv.on('CREATE', Foos, (req, next) => { isMany(req); return next() })
+srv.before('CREATE', Foo, req => { isMany(req); return req.data })
+srv.before('CREATE', Foos, req => isMany(req))
+srv.after('CREATE', Foo, (data) => { isMany(data); return data })
+srv.after('CREATE', Foos, (data) => isMany(data))
+
 // Handlers with classes. Singular and plural are to be reflected in what the handler receives
-srv.on('READ', Foo, (req, next) => { req.data.x?.toFixed(); return next() })
-srv.on('READ', Foos, (req, next) => { req.data.at(0)?.x?.toFixed(); return next() })
-srv.before('READ', Foo, req => { req.data.x?.toFixed(); return req.data })
-srv.before('READ', Foos, req => req.data[0].x?.toFixed())
-srv.after('READ', Foo, (data) => { data?.x.toFixed(); return data })
-srv.after('READ', Foos, (data) => data?.at(0)?.x?.toFixed())
+srv.on('READ', Foo, (req, next) => { isMany(req); return next() })
+srv.on('READ', Foos, (req, next) => { isMany(req); return next() })
+srv.before('READ', Foo, req => { isMany(req); return req.data })
+srv.before('READ', Foos, req => isMany(req))
+srv.after('READ', Foo, (data) => { isOne(data); return data })
+srv.after('READ', Foos, (data) => isMany(data))
+
+srv.on('UPDATE', Foo, (req, next) => { isMany(req); return next() })
+srv.on('UPDATE', Foos, (req, next) => { isMany(req); return next() })
+srv.before('UPDATE', Foo, req => { isMany(req); return req.data })
+srv.before('UPDATE', Foos, req => isMany(req))
+srv.after('UPDATE', Foo, (data) => { isMany(data); return data })
+srv.after('UPDATE', Foos, (data) => isMany(data))
+
+srv.on('DELETE', Foo, (req, next) => { isMany(req); return next() })
+srv.on('DELETE', Foos, (req, next) => { isMany(req); return next() })
+srv.before('DELETE', Foo, req => { isMany(req); return req.data })
+srv.before('DELETE', Foos, req => isMany(req))
+srv.after('DELETE', Foo, (data) => { isMany(data); return data })
+srv.after('DELETE', Foos, (data) => isMany(data))
+
 
 srv.before("UPDATE", "TestEntity", async (req) => {
   await SELECT.one.from(req.subject)


### PR DESCRIPTION
Only `.after('READ', ...)` differentiates between singular and plural. All other cases assume the plural.