### PR TITLE
Remove `cds.env.mtx` from types

### DIFF
--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -8,7 +8,6 @@ export const env: {
   build: any,
   hana: any,
   i18n: any,
-  mtx: any,
   requires: any,
   folders: any,
   odata: any,


### PR DESCRIPTION
This is a property solely used by old MTX, which will be deprecated with cds8.