### PR TITLE
Define types for `cds.env.folders`

### DIFF
--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -15,7 +15,7 @@ export const env: {
     db: string,
     srv: string,
     fts: string,
-    [key: string]: string
+    [key: string]: string,
   },
   odata: any,
   query: any,

--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -11,6 +11,13 @@ export const env: {
   mtx: any,
   requires: any,
   folders: any,
+  folders: {
+    app: string,
+    db: string,
+    srv: string,
+    fts: string,
+    [key: string]: string
+  },
   odata: any,
   query: any,
   sql: any,

--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -9,7 +9,6 @@ export const env: {
   hana: any,
   i18n: any,
   requires: any,
-  folders: any,
   folders: {
     app: string,
     db: string,

--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -15,7 +15,7 @@ export const env: {
     db: string,
     srv: string,
     fts: string,
-    [key: string]: string,
+    [key: string]: string, // to allow additional values
   },
   odata: any,
   query: any,


### PR DESCRIPTION
A little nicer type completion for `cds.env.folders`. The list should be exhaustive, but I added a `[key: string]: string` at the end so TypeScript projects don't break if new properties are added that are missing here.