### PR TITLE
Types for `cds.requires`

### DIFF
--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -9,19 +9,19 @@ type TODO = any
 export const env: {
   build: TODO,
   hana: TODO,
-  requires: _requires,
   i18n: {
     languages: string[],
-    default_language: string
+    default_language: string,
     folders: string[],
-    [key: string]: any
+    [key: string]: any,
   },
+  requires: _requires,
   folders: {
     app: string,
     db: string,
     srv: string,
     fts: string,
-    [key: string]: string
+    [key: string]: string,
   },
   odata: TODO,
   query: TODO,
@@ -31,7 +31,7 @@ export const env: {
 type _extensibility = boolean | {
   model: string[],
   tenantCheckInterval: number = 60000,
-  [key: string]: any
+  [key: string]: any,
 }
 
 type _binding = {
@@ -40,7 +40,7 @@ type _binding = {
   org?: string,
   space?: string,
   instance?: string,
-  key?: string
+  key?: string,
 }
 
 interface User {
@@ -69,13 +69,13 @@ type _requires = {
     [key: string]: any
   },
   db: {
-    kind: 'hana' | 'sqlite' | 'sql' | string
+    kind: 'hana' | 'sqlite' | 'sql' | string,
     binding?: _binding
   },
   multitenancy: boolean | { kind: string, jobs: {
     clusterSize: number,
     workerSize: number,
-    t0: string
+    t0: string,
   }},
   toggles: boolean,
   extensibility: _extensibility,
@@ -92,7 +92,7 @@ type _binding = {
   org?: string,
   space?: string,
   instance?: string,
-  key?: string
+  key?: string,
 }
 
 type _credentials = {
@@ -102,7 +102,7 @@ type _credentials = {
   xsappname?: string,
   certurl?: string,
   certificate?: string,
-  [key: string]: any
+  [key: string]: any,
 }
 
 export const requires: _requires

--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -21,7 +21,7 @@ export const env: {
     db: string,
     srv: string,
     fts: string,
-    [key: string]: string,
+    [key: string]: string, // to allow additional values
   },
   odata: TODO,
   query: TODO,

--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -28,22 +28,22 @@ export const env: {
   sql: TODO,
 } & { [key: string]: any } // to allow additional values we have not yet captured
 
-interface User {
+interface MockUser {
   tenant?: string
   roles?: string[]
   features?: string[]
 }
 
-interface Users {
-  alice: User, bob: User, carol: User, dave: User, erin: User, fred: User
-  [key: string]: User | undefined
+interface MockUsers {
+  alice: MockUser, bob: MockUser, carol: MockUser, dave: MockUser, erin: MockUser, fred: MockUser
+  [key: string]: MockUser | undefined
 }
 
 type _requires = {
   auth: {
     kind: 'dummy' | 'mocked' | 'basic' | 'xsuaa' | 'ias' | string,
     impl: string,
-    users?: Users,
+    users?: MockUsers,
     tenants?: {
       [key: string]: {
         features?: string[]
@@ -65,7 +65,7 @@ type _requires = {
   toggles: boolean,
   extensibility: boolean | {
     model: string[],
-    tenantCheckInterval: number = 60000,
+    tenantCheckInterval: number,
     [key: string]: any,
   },
   messaging: {

--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -61,11 +61,13 @@ type _requires = {
   db: {
     kind: 'hana' | 'sqlite' | 'sql' | string,
     binding?: _binding,
+    [key: string]: any,
   },
   multitenancy: boolean | { kind: string, jobs: {
     clusterSize: number,
     workerSize: number,
     t0: string,
+    [key: string]: any,
   },},
   toggles: boolean,
   extensibility: boolean | {
@@ -76,6 +78,7 @@ type _requires = {
   messaging: {
     kind: 'file-based-messaging' | 'redis-messaging' | 'local-messaging' | 'enterprise-messaging' | 'enterprise-messaging-shared' | string,
     format: 'cloudevents' | string,
+    [key: string]: any,
   },
   [key: string]: any,
 }

--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -28,21 +28,6 @@ export const env: {
   sql: TODO,
 } & { [key: string]: any } // to allow additional values we have not yet captured
 
-type _extensibility = boolean | {
-  model: string[],
-  tenantCheckInterval: number = 60000,
-  [key: string]: any,
-}
-
-type _binding = {
-  type: 'cf' | 'k8s' | string,
-  apiEndpoint?: string,
-  org?: string,
-  space?: string,
-  instance?: string,
-  key?: string,
-}
-
 interface User {
   tenant?: string
   roles?: string[]
@@ -78,7 +63,11 @@ type _requires = {
     t0: string,
   }},
   toggles: boolean,
-  extensibility: _extensibility,
+  extensibility: boolean | {
+    model: string[],
+    tenantCheckInterval: number = 60000,
+    [key: string]: any,
+  },
   messaging: {
     kind: 'file-based-messaging' | 'redis-messaging' | 'local-messaging' | 'enterprise-messaging' | 'enterprise-messaging-shared' | string,
     format: 'cloudevents' | string

--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -7,15 +7,78 @@
 export const env: {
   build: any,
   hana: any,
-  i18n: any,
-  requires: any,
-  folders: any,
+  requires: _requires,
+  folders: {
+    app: string,
+    db: string,
+    srv: string,
+    fts: string,
+    [key: string]: string
+  },
+  i18n: {
+    languages: [string],
+    default_language: string
+    folders: [string],
+    [key: string]: any
+  },
   odata: any,
   query: any,
   sql: any,
 } & { [key: string]: any } // to allow additional values we have not yet captured
 
-export const requires: any
+type _extensibility = boolean | {
+  model: [string],
+  tenantCheckInterval: number = 1000
+}
+
+type _binding = {
+  type: 'cf' | 'k8s' | string,
+  apiEndpoint?: 'string',
+  org?: 'string',
+  space?: 'string',
+  instance?: 'string',
+  key?: 'string'
+}
+
+type _requires = {
+  auth: {
+    kind: 'dummy' | 'mocked' | 'basic' | 'xsuaa' | 'ias' | string,
+    impl: string,
+    users?: {
+      [key: 'alice' | 'bob' | 'carol' | 'dave' | 'erin' | 'fred' | string]: {
+        tenant?: string
+        roles?: [string],
+        features?: [string]
+      }
+    },
+    tenants?: {
+      [key: string]: {
+        features?: [string]
+      }
+    },
+    credentials?: {
+
+    }
+  },
+  db: {
+    kind: 'hana' | 'sqlite' | 'sql' | string
+  },
+  multitenancy: boolean | { kind: string, jobs: { clusterSize: number, workerSize: number } },
+  extensibility: _extensibility,
+  messaging: {
+    kind: 'file-based-messaging' | 'redis-messaging' | 'local-messaging' | 'enterprise-messaging' | 'enterprise-messaging-shared'
+  },
+}
+
+type _requiresMTX = {
+  'cds.xt.SaasProvisioningService': boolean,
+  'cds.xt.DeploymentService': boolean,
+  'cds.xt.ModelProviderService': boolean,
+  'cds.xt.JobsService': boolean,
+  'cds.xt.ExtensibilityService': boolean,
+}
+
+export const requires: _requires
 export const version: string
 export const home: string
 export const root: string

--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -4,9 +4,11 @@
  * filtered through the currently active profiles, thus highly dependent on the current working
  * directory and process environment.
  */
+type TODO = any
+
 export const env: {
-  build: any,
-  hana: any,
+  build: TODO,
+  hana: TODO,
   requires: _requires,
   folders: {
     app: string,
@@ -16,66 +18,91 @@ export const env: {
     [key: string]: string
   },
   i18n: {
-    languages: [string],
+    languages: string[],
     default_language: string
-    folders: [string],
+    folders: string[],
     [key: string]: any
   },
-  odata: any,
-  query: any,
-  sql: any,
+  odata: TODO,
+  query: TODO,
+  sql: TODO,
 } & { [key: string]: any } // to allow additional values we have not yet captured
 
 type _extensibility = boolean | {
-  model: [string],
-  tenantCheckInterval: number = 1000
+  model: string[],
+  tenantCheckInterval: number = 60000,
+  [key: string]: any
 }
 
 type _binding = {
   type: 'cf' | 'k8s' | string,
-  apiEndpoint?: 'string',
-  org?: 'string',
-  space?: 'string',
-  instance?: 'string',
-  key?: 'string'
+  apiEndpoint?: string,
+  org?: string,
+  space?: string,
+  instance?: string,
+  key?: string
+}
+
+interface User {
+  tenant?: string
+  roles?: string[]
+  features?: string[]
+}
+
+interface Users {
+  alice: User, bob: User, carol: User, dave: User, erin: User, fred: User
+  [key: string]: User | undefined
 }
 
 type _requires = {
   auth: {
     kind: 'dummy' | 'mocked' | 'basic' | 'xsuaa' | 'ias' | string,
     impl: string,
-    users?: {
-      [key: 'alice' | 'bob' | 'carol' | 'dave' | 'erin' | 'fred' | string]: {
-        tenant?: string
-        roles?: [string],
-        features?: [string]
-      }
-    },
+    users?: Users,
     tenants?: {
       [key: string]: {
-        features?: [string]
+        features?: string[]
       }
     },
-    credentials?: {
-
-    }
+    credentials?: _credentials,
+    binding?: _binding,
+    [key: string]: any
   },
   db: {
     kind: 'hana' | 'sqlite' | 'sql' | string
+    binding?: _binding
   },
-  multitenancy: boolean | { kind: string, jobs: { clusterSize: number, workerSize: number } },
+  multitenancy: boolean | { kind: string, jobs: {
+    clusterSize: number,
+    workerSize: number,
+    t0: string
+  }},
+  toggles: boolean,
   extensibility: _extensibility,
   messaging: {
-    kind: 'file-based-messaging' | 'redis-messaging' | 'local-messaging' | 'enterprise-messaging' | 'enterprise-messaging-shared'
+    kind: 'file-based-messaging' | 'redis-messaging' | 'local-messaging' | 'enterprise-messaging' | 'enterprise-messaging-shared' | string,
+    format: 'cloudevents' | string
   },
+  [key: string]: any
 }
 
-type _requiresMTX = {
-  'cds.xt.SaasProvisioningService': boolean,
-  'cds.xt.DeploymentService': boolean,
-  'cds.xt.ModelProviderService': boolean,
-  'cds.xt.JobsService': boolean,
-  'cds.xt.ExtensibilityService': boolean,
+type _binding = {
+  type: 'cf' | 'k8s' | string,
+  apiEndpoint?: string,
+  org?: string,
+  space?: string,
+  instance?: string,
+  key?: string
+}
+
+type _credentials = {
+  clientid?: string,
+  clientsecret?: string,
+  url?: string,
+  xsappname?: string,
+  certurl?: string,
+  certificate?: string,
+  [key: string]: any
 }
 
 export const requires: _requires

--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -35,7 +35,12 @@ interface MockUser {
 }
 
 interface MockUsers {
-  alice: MockUser, bob: MockUser, carol: MockUser, dave: MockUser, erin: MockUser, fred: MockUser
+  alice: MockUser
+  bob: MockUser
+  carol: MockUser
+  dave: MockUser
+  erin: MockUser
+  fred: MockUser
   [key: string]: MockUser | undefined
 }
 
@@ -46,22 +51,22 @@ type _requires = {
     users?: MockUsers,
     tenants?: {
       [key: string]: {
-        features?: string[]
-      }
+        features?: string[],
+      },
     },
     credentials?: _credentials,
     binding?: _binding,
-    [key: string]: any
+    [key: string]: any,
   },
   db: {
     kind: 'hana' | 'sqlite' | 'sql' | string,
-    binding?: _binding
+    binding?: _binding,
   },
   multitenancy: boolean | { kind: string, jobs: {
     clusterSize: number,
     workerSize: number,
     t0: string,
-  }},
+  },},
   toggles: boolean,
   extensibility: boolean | {
     model: string[],
@@ -70,9 +75,9 @@ type _requires = {
   },
   messaging: {
     kind: 'file-based-messaging' | 'redis-messaging' | 'local-messaging' | 'enterprise-messaging' | 'enterprise-messaging-shared' | string,
-    format: 'cloudevents' | string
+    format: 'cloudevents' | string,
   },
-  [key: string]: any
+  [key: string]: any,
 }
 
 type _binding = {

--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -10,18 +10,18 @@ export const env: {
   build: TODO,
   hana: TODO,
   requires: _requires,
+  i18n: {
+    languages: string[],
+    default_language: string
+    folders: string[],
+    [key: string]: any
+  },
   folders: {
     app: string,
     db: string,
     srv: string,
     fts: string,
     [key: string]: string
-  },
-  i18n: {
-    languages: string[],
-    default_language: string
-    folders: string[],
-    [key: string]: any
   },
   odata: TODO,
   query: TODO,

--- a/test/typescript/apis/project/cds-env.ts
+++ b/test/typescript/apis/project/cds-env.ts
@@ -1,0 +1,31 @@
+import { env } from '../../../..'
+
+env.folders.db = ''
+env.folders.srv = ''
+env.folders.app = ''
+env.folders.fts = ''
+env.folders.foo = ''
+
+env.build = ''
+env.hana = ''
+
+env.requires.auth.kind = ''
+env.requires.auth.credentials!.url = ''
+env.requires.auth.credentials!.clientid = ''
+env.requires.auth.binding!.key = ''
+env.requires.auth.binding!.type = 'cf'
+env.requires.auth.tenants!.foo.features = []
+
+env.requires.auth.users!.alice.roles = []
+env.requires.auth.users!.bob.features = []
+env.requires.auth.users!.carol.tenant = ''
+env.requires.auth.users!.dave = {}
+env.requires.auth.users!.TEST = {}
+
+env.requires.db.kind = 'hana'
+env.requires.db.binding!.key = 'cf'
+
+env.requires.multitenancy = { kind: 'shared', jobs: { clusterSize:1, workerSize:1, t0:'', foo:'' }}
+env.requires.messaging = { kind: '', format: '', foo: '' }
+
+env.foo = {}


### PR DESCRIPTION
I went through the `cds` + `cds-dk` + `cds-mtxs` repos to type `cds.requires` as much as possible.

Most objects allow more fields with `[key: string]: any`-style types to make sure strict TypeScript projects don't break.

Still, this gives you nice suggestions for fields it already knows, even for JS-only projects.