### PR TITLE
Remove forall

### DIFF
--- a/apis/linked.d.ts
+++ b/apis/linked.d.ts
@@ -45,13 +45,6 @@ export interface LinkedCSN extends Omit<CSN, 'definitions'> {
   foreach(visitor: Visitor, defs?: LinkedDefinitions): this
 
   /**
-	 * Same as foreach but recursively visits each element definition
-	 * @see [capire](https://github.wdf.sap.corp/pages/cap/node.js/api#cds-reflect-foreach)
-	 */
-  forall(x: Filter, visitor: Visitor, defs?: LinkedDefinitions): this
-  forall(visitor: Visitor, defs?: LinkedDefinitions): this
-
-  /**
 	 * Fetches definitions declared as children of a given parent context or service.
 	 * It fetches all definitions whose fully-qualified names start with the parent's name.
 	 * Returns the found definitions as an object with the local names as keys.


### PR DESCRIPTION
`forall` is no longer present as its own method in CAPire, beyond a [brief mention](https://cap.cloud.sap/docs/node.js/cds-reflect#foreach), so I assume it is no longer part of the API?