### PR TITLE
Expose linked definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.3.0 - tbd
 
+## Version 0.3.0-beta.1 - 2014-05-23
+
 ### Added
 - Added signatures for `cds.outboxed` and `cds.unboxed`
 - Added signature for `cds.middlewares.add`
 - More `cds.env` properties and types
+- Exposed types related to `cds.linked` through the facade. Types describing unlinked CSN should generally not be needed, but are still available through `cds.csn.…`
 
 ### Changed
 - Improved signatures for `cds.env.folders` and `cds.env.i18n` from `any` to a more descriptive type

--- a/apis/cds.d.ts
+++ b/apis/cds.d.ts
@@ -7,17 +7,19 @@ export * from './events'
 export * from './utils'
 export * from './cqn'
 export * from './global'
+export * from './linked'
 export { log, debug } from './log'
 export { test } from './test'
-
-// FIXME: sort out what needs to be exported from csn/linked and under which namespace
-// export { Association, CSN, Definition, Extension, Element, EntityElements, FQN, kinds } from './csn'
-// export { Definitions, LinkedCSN, LinkedDefinition, LinkedAssociation, LinkedEntity, Filter, Visitor } from './linked'
 
 // API extractor cannot handle export * as ql from './ql', so split it into an import and an export statement
 import * as ql from './ql'
 export { ql }
 export { QLExtensions } from './ql' // cds-ql.ts test tries to import this from top level? Correct? Or ql.QLExtensions?
+
+import * as csn from './csn'
+// clashes with linked and not really needed for consumers,
+// so only available in namespaced form (same fix for rollup as above)
+export { csn }
 
 // trick to work around "delete" as reserved identifier
 import { Service } from './services'

--- a/apis/cqn.d.ts
+++ b/apis/cqn.d.ts
@@ -22,8 +22,8 @@ export type INSERT = { INSERT: {
   into: ref | name,
   entries: data[],
   columns: string[],
-  values: scalar[],
-  rows: scalar[][],
+  values: primitive[],
+  rows: primitive[][],
   as: SELECT,
 }, }
 
@@ -31,8 +31,8 @@ export type UPSERT = { UPSERT: {
   into: ref | name,
   columns: string[],
   entries: data[],
-  values: scalar[],
-  rows: scalar[][],
+  values: primitive[],
+  rows: primitive[][],
 }, }
 
 export type UPDATE = { UPDATE: {
@@ -58,7 +58,7 @@ export type DROP = { DROP: {
 }, }
 
 /** @private */
-type scalar = number | string | boolean | null
+type primitive = number | string | boolean | null
 
 /** @private */
 type data = Record<string, any>

--- a/apis/events.d.ts
+++ b/apis/events.d.ts
@@ -1,4 +1,4 @@
-import { LinkedDefinition } from './linked'
+import { Definition } from './linked'
 import { Query } from './cqn'
 import { ref } from './cqn'
 import * as express from 'express'
@@ -51,7 +51,7 @@ export class Request extends Event {
 
   path: string
 
-  target: LinkedDefinition
+  target: Definition
 
   /**
    * Shortcut to {@link Request.target | target (entity) name}

--- a/apis/linked.d.ts
+++ b/apis/linked.d.ts
@@ -1,14 +1,14 @@
-import { CSN } from './csn'
+import * as csn from './csn'
 import { IterableMap } from './internal/util'
-import { LinkedDefinitions, any_, entity, service } from './linked/classes'
+import { Definitions, any_, entity, service_ } from './linked/classes'
 
 export type ModelPart<T extends any_> = IterableMap<T> & ((namespace: string) => IterableMap<T>)
-type Visitor = (def: any_, name: string, parent: any_, defs: LinkedDefinitions) => void
+type Visitor = (def: any_, name: string, parent: any_, defs: Definitions) => void
 type Filter = string | (<T extends any_ = any_>(def: T) => boolean)
 
-export type LinkedDefinition = any_
+export type Definition = any_
 
-export interface LinkedCSN extends Omit<CSN, 'definitions'> {
+export interface CSN extends Omit<csn.CSN, 'definitions'> {
 
   /**
 	 * Fetches definitions matching the given filter, returning an iterator on them.
@@ -20,13 +20,13 @@ export interface LinkedCSN extends Omit<CSN, 'definitions'> {
 	 *   let entities = m.all('entity')        //> equivalent shortcut
 	 * ```
 	 */
-  each<T extends any_>(x: Filter, defs?: LinkedDefinitions<T>): IterableIterator<T>
+  each<T extends any_>(x: Filter, defs?: Definitions<T>): IterableIterator<T>
 
   /**
 	 * Fetches definitions matching the given filter, returning them in an array.
 	 * Convenience shortcut for `[...reflect.each('entity')]`
 	 */
-  all<T extends any_>(x: Filter, defs?: LinkedDefinitions<T>): T[]
+  all<T extends any_>(x: Filter, defs?: Definitions<T>): T[]
 
   /**
 	 * Fetches definitions matching the given filter, returning the first match, if any.
@@ -35,21 +35,21 @@ export interface LinkedCSN extends Omit<CSN, 'definitions'> {
 	 * @param x - the filter
 	 * @param defs - the definitions to fetch in, default: `this.definitions`
 	 */
-  find<T extends any_>(x: Filter, defs?: LinkedDefinitions<T>): T | undefined
+  find<T extends any_>(x: Filter, defs?: Definitions<T>): T | undefined
 
   /**
 	 * Calls the visitor for each definition matching the given filter.
 	 * @see [capire](https://github.wdf.sap.corp/pages/cap/node.js/api#cds-reflect-foreach)
 	 */
-  foreach(x: Filter, visitor: Visitor, defs?: LinkedDefinitions): this
-  foreach(visitor: Visitor, defs?: LinkedDefinitions): this
+  foreach(x: Filter, visitor: Visitor, defs?: Definitions): this
+  foreach(visitor: Visitor, defs?: Definitions): this
 
   /**
 	 * Same as foreach but recursively visits each element definition
 	 * @see [capire](https://github.wdf.sap.corp/pages/cap/node.js/api#cds-reflect-foreach)
 	 */
-  forall(x: Filter, visitor: Visitor, defs?: LinkedDefinitions): this
-  forall(visitor: Visitor, defs?: LinkedDefinitions): this
+  forall(x: Filter, visitor: Visitor, defs?: Definitions): this
+  forall(visitor: Visitor, defs?: Definitions): this
 
   /**
 	 * Fetches definitions declared as children of a given parent context or service.
@@ -63,7 +63,7 @@ export interface LinkedCSN extends Omit<CSN, 'definitions'> {
 	 * @param parent - either the parent itself or its fully-qualified name
 	 * @param filter - an optional filter to apply before picking a child
 	 */
-  childrenOf(parent: any | string, filter?: ((def: any_) => boolean)): LinkedDefinitions
+  childrenOf(parent: any | string, filter?: ((def: any_) => boolean)): Definitions
 
   /**
 	 * Provides convenient access to the model's top-level definitions.
@@ -84,9 +84,8 @@ export interface LinkedCSN extends Omit<CSN, 'definitions'> {
   exports: IterableMap<any_>
   definitions: IterableMap<any_>
   entities: ModelPart<entity>
-  services: ModelPart<service>
+  services: ModelPart<service_>
 
 }
 
-// FIXME: only for compat in ql.d.ts and services.d.ts, remove asap
-export type LinkedEntity = entity
+export * from './linked/classes'

--- a/apis/linked/classes.d.ts
+++ b/apis/linked/classes.d.ts
@@ -32,10 +32,10 @@ type Column = { ref: [string], as?: string }
 /**
  * @see [capire](https://pages.github.tools.sap/cap/docs/node.js/cds-reflect#iterable)
  */
-export type LinkedDefinitions<T extends any_ = any_> = IterableMap<T>
+export type Definitions<T extends any_ = any_> = IterableMap<T>
 
 interface WithElements {
-  elements: LinkedDefinitions<type>
+  elements: Definitions<type>
 }
 
 declare interface any_ extends csn.any_ {}
@@ -51,7 +51,7 @@ declare class any_<K extends kinds = kinds> {
 declare const any: typeof any_
 
 declare class aspect<K extends kinds = 'aspect'> extends type<K> implements WithElements {
-  elements: LinkedDefinitions<type<'type'>>
+  elements: Definitions<type<'type'>>
 }
 declare interface type extends Omit<csn.type, 'items'> {
   items: type
@@ -96,27 +96,29 @@ declare interface struct extends Omit<csn.struct, 'items' | 'elements'> {}
 declare class struct<K extends kinds = 'elements' | 'type'> extends type<K> implements WithElements {
   is_struct: true
 
-  elements: LinkedDefinitions<type<'type'>>
+  elements: Definitions<type<'type'>>
 }
 
-declare interface context extends csn.context {}
-declare class context extends any_ { }
+// clashes with services.context when exported from facade
+declare interface context_ extends csn.context {}
+declare class context_ extends any_ { }
 
+// clashes with server.service when exported from facade
 /**
  * @see [capire](https://pages.github.tools.sap/cap/docs/node.js/cds-reflect#cds-service)
  */
-declare interface service extends csn.service {}
-declare class service extends context {
+declare interface service_ extends csn.service {}
+declare class service_ extends context_ {
   is_service: true
-  get entities (): LinkedDefinitions<entity>
-  get types (): LinkedDefinitions<type>
-  get events (): LinkedDefinitions<event>
-  get actions (): LinkedDefinitions<action>
+  get entities (): Definitions<entity>
+  get types (): Definitions<type>
+  get events (): Definitions<event>
+  get actions (): Definitions<action>
 
   /**
    * @deprecated use `.actions` instead
    */
-  get operations (): LinkedDefinitions<action>
+  get operations (): Definitions<action>
 
   /**
    * @alpha
@@ -135,13 +137,13 @@ declare interface entity extends Omit<csn.entity, 'elements' | 'items' | 'keys' 
 declare class entity extends struct<'entity'> {
   is_entity: true
 
-  keys: LinkedDefinitions<type>
+  keys: Definitions<type>
 
-  associations: LinkedDefinitions<Association>
+  associations: Definitions<Association>
 
-  compositions: LinkedDefinitions<Composition>
+  compositions: Definitions<Composition>
 
-  actions: LinkedDefinitions<action>
+  actions: Definitions<action>
 
   texts?: entity
 
@@ -168,7 +170,7 @@ declare class Composition extends Association {
 }
 
 declare type ManagedAssociation = Association & {
-  foreignKeys: LinkedDefinitions<type>,
+  foreignKeys: Definitions<type>,
   keys: Column[],
 }
 

--- a/apis/models.d.ts
+++ b/apis/models.d.ts
@@ -1,7 +1,7 @@
 import { Query as CQN, expr, _xpr } from './cqn'
-import { LinkedCSN } from './linked'
+import * as ln from './linked'
 import * as LinkedClasses from './linked/classes'
-import { CSN } from './csn'
+import * as csn from './csn'
 
 type _flavor = 'parsed' | 'xtended' | 'inferred'
 type _odata_options = {
@@ -33,7 +33,7 @@ type filename = string
  * including required services.
  * Should only be ever set explictly in test scenarios!
  */
-export let model: LinkedCSN | undefined
+export let model: ln.CSN | undefined
 
 /**
  * Provides a set of methods to parse a given model, query or expression.
@@ -42,8 +42,8 @@ export let model: LinkedCSN | undefined
 export const parse: {
 
   /** Shortcut to `cds.parse.cdl()` */
-  (cdl: CDL): CSN,
-  cdl (cdl: CDL): CSN,
+  (cdl: CDL): csn.CSN,
+  cdl (cdl: CDL): csn.CSN,
   cql (src: string): CQN,
   expr (src: string): expr,
   xpr (src: string): _xpr,
@@ -56,13 +56,13 @@ export const parse: {
  * Essentially a shortcut for `cds.compile.to.csn(files)`
  * @param files - filenames of models or if folder containing models
  */
-export function get (files: '*' | filename | filename[], o?: _options): Promise<CSN>
+export function get (files: '*' | filename | filename[], o?: _options): Promise<csn.CSN>
 
 /**
  * Shortcut for `cds.get(files, 'inferred')`
  * @param files - filenames of models or if folder containing models
  */
-export function load (files: '*' | filename | filename[], o?: _options): Promise<CSN>
+export function load (files: '*' | filename | filename[], o?: _options): Promise<csn.CSN>
 
 
 /**
@@ -81,7 +81,7 @@ export const linked: {
    * Turns the given plain CSN model into a linked model
    * @see [capire](https://cap.cloud.sap/docs/node.js/cds-reflect)
    */
-  (model: CSN): LinkedCSN,
+  (model: csn.CSN): ln.CSN,
 
   /**
    * Base classes of linked definitions from reflected models.
@@ -94,7 +94,7 @@ export const linked: {
  * Turns the given plain CSN model into a reflected model
  * @see [capire](https://cap.cloud.sap/docs/node.js/cds-reflect)
  */
-export function reflect (model: CSN): LinkedCSN
+export function reflect (model: csn.CSN): ln.CSN
 
 /**
 * Provides a set of methods to parse a given model, query or expression.
@@ -103,49 +103,49 @@ export function reflect (model: CSN): LinkedCSN
 export const compile: {
 
   /** Shortcut for `cds.compile.to.csn()` */
-  cdl (model: CDL, o?: _options): CSN,
+  cdl (model: CDL, o?: _options): csn.CSN,
 
   for: {
-    odata (model: CSN, o?: _options): CSN,
-    sql (model: CSN, o?: _options): CSN,
+    odata (model: csn.CSN, o?: _options): csn.CSN,
+    sql (model: csn.CSN, o?: _options): csn.CSN,
   },
   to: {
     parsed: {
-      csn (files: filename[], o?: _options): Promise<CSN>,
-      csn (model: CDL, o?: _options): CSN,
+      csn (files: filename[], o?: _options): Promise<csn.CSN>,
+      csn (model: CDL, o?: _options): csn.CSN,
     },
     xtended: {
-      csn (files: filename[], o?: _options): Promise<CSN>,
-      csn (model: CDL, o?: _options): CSN,
+      csn (files: filename[], o?: _options): Promise<csn.CSN>,
+      csn (model: CDL, o?: _options): csn.CSN,
     },
     inferred: {
-      csn (files: filename[], o?: _options): Promise<CSN>,
-      csn (model: CDL, o?: _options): CSN,
+      csn (files: filename[], o?: _options): Promise<csn.CSN>,
+      csn (model: CDL, o?: _options): csn.CSN,
     },
-    csn (files: filename[], o?: _options): Promise<CSN>,
-    csn (model: CDL, o?: _options): CSN,
-    yml (model: CSN, o?: _options): YAML,
-    yaml (model: CSN, o?: _options): YAML,
-    json (model: CSN, o?: _options): JSON,
-    sql (model: CSN, o?: _options): SQL[],
-    cdl (model: CSN, o?: _options): CDL | Iterable<[CDL, { file: filename }]>,
-    edm (model: CSN, o?: _options | _odata_options): EDM | string,
-    edmx (model: CSN, o?: _options | _odata_options): EDMX | Iterable<[EDMX, { file: filename }]>,
-    hdbcds (model: CSN, o?: _options): SQL | Iterable<[SQL, { file: filename }]>,
-    hdbtable (model: CSN, o?: _options): SQL | Iterable<[SQL, { file: filename }]>,
+    csn (files: filename[], o?: _options): Promise<csn.CSN>,
+    csn (model: CDL, o?: _options): csn.CSN,
+    yml (model: csn.CSN, o?: _options): YAML,
+    yaml (model: csn.CSN, o?: _options): YAML,
+    json (model: csn.CSN, o?: _options): JSON,
+    sql (model: csn.CSN, o?: _options): SQL[],
+    cdl (model: csn.CSN, o?: _options): CDL | Iterable<[CDL, { file: filename }]>,
+    edm (model: csn.CSN, o?: _options | _odata_options): EDM | string,
+    edmx (model: csn.CSN, o?: _options | _odata_options): EDMX | Iterable<[EDMX, { file: filename }]>,
+    hdbcds (model: csn.CSN, o?: _options): SQL | Iterable<[SQL, { file: filename }]>,
+    hdbtable (model: csn.CSN, o?: _options): SQL | Iterable<[SQL, { file: filename }]>,
   },
 
   /** Fluent API variant */
-  (model: CSN | CDL): {
+  (model: csn.CSN | CDL): {
     for: {
-      odata (o?: _options): CSN,
-      sql (o?: _options): CSN,
+      odata (o?: _options): csn.CSN,
+      sql (o?: _options): csn.CSN,
     },
     to: {
-      parsed: { csn (o?: _options): CSN },
-      xtended: { csn (o?: _options): CSN },
-      inferred: { csn (o?: _options): CSN },
-      csn (o?: _options): CSN,
+      parsed: { csn (o?: _options): csn.CSN },
+      xtended: { csn (o?: _options): csn.CSN },
+      inferred: { csn (o?: _options): csn.CSN },
+      csn (o?: _options): csn.CSN,
       yml (o?: _options): YAML,
       yaml (o?: _options): YAML,
       json (o?: _options): JSON,
@@ -161,14 +161,14 @@ export const compile: {
   /** Async fluent variant reading from files */
   (files: filename[]): {
     for: {
-      odata (o?: _options): Promise<CSN>,
-      sql (o?: _options): Promise<CSN>,
+      odata (o?: _options): Promise<csn.CSN>,
+      sql (o?: _options): Promise<csn.CSN>,
     },
     to: {
-      parsed: { csn (o?: _options): Promise <CSN> },
-      xtended: { csn (o?: _options): Promise <CSN> },
-      inferred: { csn (o?: _options): Promise <CSN> },
-      csn (o?: _options): Promise <CSN>,
+      parsed: { csn (o?: _options): Promise <csn.CSN> },
+      xtended: { csn (o?: _options): Promise <csn.CSN> },
+      inferred: { csn (o?: _options): Promise <csn.CSN> },
+      csn (o?: _options): Promise <csn.CSN>,
       yml (o?: _options): Promise <YAML>,
       yaml (o?: _options): Promise <YAML>,
       json (o?: _options): Promise <JSON>,

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -1,7 +1,7 @@
 import { Definition, EntityElements } from './csn'
 import * as CQN from './cqn'
 import { Constructable, ArrayConstructable, SingularType, PluralType } from './internal/inference'
-import { LinkedEntity } from './linked'
+import * as linked from './linked'
 import { ref, column_expr } from './cqn'
 
 export type Query = CQN.Query
@@ -23,7 +23,7 @@ type QLExtensions<T> = T extends QLExtensions_<any> ? T : QLExtensions_<T>
 /**
  * Target for any QL operation
  */
-type Target = LinkedEntity | Definition | string
+type Target = linked.entity | Definition | string
 
 /**
  * QLExtensions are properties that are attached to entities in CQL contexts.

--- a/apis/server.d.ts
+++ b/apis/server.d.ts
@@ -7,6 +7,7 @@ import { Application, RequestHandler } from 'express'
 import { XOR } from './internal/util'
 
 type _cds = typeof cds
+type cds_services = { [name: string]: Service }
 
 export const connect: {
 
@@ -124,9 +125,6 @@ export type service = {
 	 */
   providers: Service[],
 }
-
-
-type cds_services = { [name: string]: Service }
 
 interface cds_serve_fluent {
   from (model: string | CSN): cds_serve_fluent

--- a/apis/services.d.ts
+++ b/apis/services.d.ts
@@ -2,9 +2,9 @@
 import { SELECT, INSERT, UPDATE, DELETE, Query, ConstructedQuery, UPSERT } from './ql'
 import { Awaitable } from './ql'
 import { ArrayConstructable, Constructable, Unwrap } from './internal/inference'
-import { ModelPart, LinkedCSN, LinkedDefinition, LinkedEntity } from './linked'
-import * as linked from './linked/classes'
-import { CSN } from './csn'
+//import { ModelPart, CSN, LinkedDefinition, LinkedEntity } from './linked'
+import * as linked from './linked'
+import * as csn from './csn'
 import { EventContext } from './events'
 import { Request } from './events'
 import { ReadableStream } from 'node:stream/web'
@@ -13,14 +13,14 @@ type Key = number | string | any
 
 export class QueryAPI {
 
-  entities: LinkedCSN['entities']
+  entities: linked.CSN['entities']
 
   /**
    * @see [docs](https://cap.cloud.sap/docs/node.js/core-services#crud-style-api)
    */
   read: {
     <T extends ArrayConstructable>(entity: T, key?: Key): Awaitable<SELECT<T>, InstanceType<T>>,
-    <T>(entity: LinkedDefinition | string, key?: Key): SELECT<T>,
+    <T>(entity: linked.Definition | string, key?: Key): SELECT<T>,
   }
 
   /**
@@ -28,7 +28,7 @@ export class QueryAPI {
    */
   create: {
     <T extends ArrayConstructable>(entity: T, key?: Key): INSERT<T>,
-    <T>(entity: LinkedDefinition | string, key?: Key): INSERT<T>,
+    <T>(entity: linked.Definition | string, key?: Key): INSERT<T>,
   }
 
   /**
@@ -52,7 +52,7 @@ export class QueryAPI {
    */
   update: {
     <T extends ArrayConstructable>(entity: T, key?: Key): UPDATE<T>,
-    <T>(entity: LinkedDefinition | string, key?: Key): UPDATE<T>,
+    <T>(entity: linked.Definition | string, key?: Key): UPDATE<T>,
   }
 
   /**
@@ -69,7 +69,7 @@ export class QueryAPI {
    */
   stream: {
     (column: string): {
-      from(entity: LinkedDefinition | string): {
+      from(entity: linked.Definition | string): {
         where(filter: any): ReadableStream,
       },
     },
@@ -79,7 +79,7 @@ export class QueryAPI {
   /**
    * @see [docs](https://cap.cloud.sap/docs/node.js/core-services#crud-style-api)
    */
-  delete<T>(entity: LinkedDefinition | string, key?: Key): DELETE<T>
+  delete<T>(entity: linked.Definition | string, key?: Key): DELETE<T>
 
   /**
    * @see [docs](https://cap.cloud.sap/docs/node.js/core-services#srv-foreach-entity)
@@ -107,7 +107,7 @@ export class Service extends QueryAPI {
 
   constructor (
     name?: string,
-    model?: CSN,
+    model?: csn.CSN,
     options?: {
       kind: string,
       impl: string | ServiceImpl,
@@ -128,31 +128,31 @@ export class Service extends QueryAPI {
    * The model from which the service's definition was loaded
    * @see [capire docs](https://cap.cloud.sap/docs/node.js/core-services)
    */
-  model: LinkedCSN
+  model: linked.CSN
 
   /**
    * Provides access to the entities exposed by a service
    * @see [capire docs](https://cap.cloud.sap/docs/node.js/core-services)
    */
-  entities: ModelPart<linked.entity>
+  entities: linked.ModelPart<linked.entity>
 
   /**
    * Provides access to the events declared by a service
    * @see [capire docs](https://cap.cloud.sap/docs/node.js/core-services)
    */
-  events: ModelPart<linked.event>
+  events: linked.ModelPart<linked.event>
 
   /**
    * Provides access to the types exposed by a service
    * @see [capire docs](https://cap.cloud.sap/docs/node.js/core-services)
    */
-  types: ModelPart<linked.type>
+  types: linked.ModelPart<linked.type>
 
   /**
    * Provides access to the operations, i.e. actions and functions, exposed by a service
    * @see [capire docs](https://cap.cloud.sap/docs/node.js/core-services)
    */
-  operations: ModelPart<linked.action>
+  operations: linked.ModelPart<linked.action>
 
   /**
    * Acts like a parameter-less constructor. Ensure to call `await super.init()` to have the base class’s handlers added.
@@ -180,7 +180,7 @@ export class Service extends QueryAPI {
     <T = any>(details: { event: types.event, data?: object, headers?: object }): Promise<T>,
     <T = any>(details: { query: ConstructedQuery, data?: object, headers?: object }): Promise<T>,
     <T = any>(details: { method: types.eventName, path: string, data?: object, headers?: object }): Promise<T>,
-    <T = any>(details: { event: types.eventName, entity: LinkedDefinition | string, data?: object, params?: object, headers?: object }): Promise<T>,
+    <T = any>(details: { event: types.eventName, entity: linked.Definition | string, data?: object, params?: object, headers?: object }): Promise<T>,
   }
 
   /**
@@ -213,7 +213,7 @@ export class Service extends QueryAPI {
   delete: {
     <T = any>(entityOrPath: types.target, data?: object): DELETE<T>,
     <T extends ArrayConstructable>(entity: T, key?: Key): DELETE<T>,
-    <T>(entity: LinkedDefinition | string, key?: Key): DELETE<T>,
+    <T>(entity: linked.Definition | string, key?: Key): DELETE<T>,
   }
 
   // The central method to dispatch events
@@ -262,7 +262,7 @@ export class ApplicationService extends Service {}
 export class MessagingService extends Service {}
 export class RemoteService extends Service {}
 export class DatabaseService extends Service {
-  deploy (model?: CSN | string): Promise<CSN>
+  deploy (model?: csn.CSN | string): Promise<csn.CSN>
   begin (): Promise<void>
   commit (): Promise<void>
   rollback (): Promise<void>
@@ -400,7 +400,7 @@ declare namespace types {
     | 'NEW' | 'EDIT' | 'PATCH' | 'SAVE'
     | 'GET' | 'PUT' | 'POST' | 'PATCH' | 'DELETE'
     | 'COMMIT' | 'ROLLBACK'
-  type target = string | LinkedDefinition | LinkedEntity | (string | LinkedDefinition | LinkedEntity)[] | ArrayConstructable
+  type target = string | linked.Definition | linked.entity | (string | linked.Definition | linked.entity)[] | ArrayConstructable
 }
 
 type SpawnOptions = {

--- a/test/typescript/apis/project/cds-linked.ts
+++ b/test/typescript/apis/project/cds-linked.ts
@@ -1,9 +1,17 @@
-import { LinkedCSN } from '../../../../apis/linked';
-import { action, aspect, entity, event, mixin, scalar, struct, type } from '../../../../apis/linked/classes';
+import { CSN } from '../../../../apis/linked';
+import { action, aspect, entity, event, mixin, scalar, struct, type } from '../../../../';
 import { _ArrayLike } from '../../../../apis/internal/util';
 import cds from '../../../..';
+import { csn } from '../../../..';
 
-const linkedCsn = undefined as unknown as LinkedCSN
+const linkedCsn = undefined as unknown as CSN
+
+// linked versions exported in facade
+const facadeStruct: struct = undefined as unknown as struct
+facadeStruct.is_struct
+const csnStruct: csn.struct = undefined as unknown as csn.struct
+// @ts-expect-error only present in linked.struct
+csnStruct.is_struct
 
 linkedCsn.exports[0].name
 linkedCsn.exports['foo'].name
@@ -82,9 +90,9 @@ cds.linked.classes.entity === entity
 cds.linked.classes.entity === event
 
 // ...via cds.builtin.classes
-cds.linked.classes.service === cds.builtin.classes.service
+cds.linked.classes.service_ === cds.builtin.classes.service_
 // @ts-expect-error
-cds.linked.classes.service === cds.builtin.classes.Composition
+cds.linked.classes.service_ === cds.builtin.classes.Composition
 
 // ... and also via facade...
 cds.linked.classes.Association === cds.Association
@@ -92,4 +100,4 @@ cds.linked.classes.Association === cds.Association
 cds.linked.classes.Association === cds.linked.classes.event
 
 // but make sure we can still call .linked(CSN)
-const ln: LinkedCSN = cds.linked({})
+const ln: CSN = cds.linked({})


### PR DESCRIPTION
Supersedes https://github.com/cap-js/cds-types/pull/11

### Exposing `cds.linked` Via Facade
Linked definitions are now exposed via the facade. They have lost their `Linked`-prefix, as users should generally not care about linkage, so only linked things are now directly available in the facade:

`LinkedEntity` → `entity`
`LinkedDefinition` → `Definition`
etc.

Their respective CSN siblings are no longer exported on top level in facade. Instead, they can be accessed via `csn. …`:

```patch
- import { Definition } from '@cap-js/cds-types'
- const myUnlinkedDefinition: Definition = …

+ import { csn } from '@cap-js/cds-types'
+ const myUnlinkedDefinition: csn.Definition = …
```
(and its variations)

### Resolution of Naming Conflicts
Some of our class definitions clash on facade level. Specifically `cds.classes.service` and `cds.classes.context` have therefore received an `_`-suffix.