### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Version 0.3.0 - tbd
+## Version 0.5.0 - TBD
+
+## Version 0.4.0 - 2024-05-23
+This is a prerelease version (`next`) as a preview for the upcoming release of cds 8.
+
 ### Fixed
 - Corrected `exist(…)` to `exists(…)`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/cds-types",
-  "version": "0.3.0-beta.1",
+  "version": "0.4.0",
   "description": "Type definitions for main packages of CAP, like `@sap/cds`",
   "repository": "github:cap-js/cds-types",
   "homepage": "https://cap.cloud.sap/",


### PR DESCRIPTION
**Pre-release** compatible with cds 8. For technical reasons, we decided to not use a `-beta` suffix, but tag it as `next`.