### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+package-lock.json @daogrady


### PR DESCRIPTION
Currently only set myself as owner for _package-lock.json_ to automatically get review requests for Dependabot PRs.