### PR TITLE
Wrap rollup file into module augmentation

### DIFF
--- a/.github/rollup-patch.js
+++ b/.github/rollup-patch.js
@@ -81,7 +81,7 @@ function replaceImports (src) {
 
   // put all exports into an augmented module declaration. Remove all "declare" modifiers
   // as they will now already be in an ambient context
-  //rollup = rollup.replaceAll('declare ','')
+  rollup = rollup.replaceAll('declare ','')
   rollup = `declare module '@sap/cds' {\n${rollup}\n}`
 
   await writeFile(rollupFile, rollup)

--- a/.github/rollup-patch.js
+++ b/.github/rollup-patch.js
@@ -4,10 +4,65 @@
 /* eslint-disable no-undef */
 const { readFile, writeFile } = require('fs/promises')
 
+/** @param {string} src */
+function _getImports (src) {
+  const named = src.matchAll(/import \* as (.*) from '(.*)'/g) ?? []
+  const destructured = src.matchAll(/import { (.*) } from '(.*)'/g) ?? []
+
+  return {
+    named: [...named].map(([,alias, package]) => ({
+      alias,
+      package
+    })),
+    destructured: [...destructured].map(([, props, package]) => ({
+      package,
+      properties: props.split(', ').map(p => p.trim())
+    }))
+  }
+}
+
+/**
+ * As we want to use model augmentation for @sap/cds, we need to keep
+ * this file as a global file. Having imports will automatically convert
+ * the file from being global to a module.
+ * We therefore have to remove all traditional imports and use
+ * type imports instead (see: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html#import-types)
+ * @param {string} src 
+ */
+function replaceImports (src) {
+  const re = id => new RegExp(`\\b${id}\\b(?!\\?)`, 'g')  // match whole word, but not if it's a type assertion (x?: T)
+  const { named, destructured } = _getImports(src)
+
+  // remove module imports
+  src = src.replaceAll(/^\s*import .* from '.*'.*$/gm, '')
+
+  // split to be able to leave out comments
+  let lines = src.split('\n')
+
+  // import * as foo from 'foo'; x: foo.bar
+  // v
+  // x: import('foo').bar
+  for (const { alias, package } of named) {
+    lines = lines.map(l => l.match(/\s*\*/) ? l : l.replaceAll(re(alias), `import('${package}')`))
+  }
+
+  // import { bar } from 'foo'; x: bar
+  // v
+  // x: import('foo').bar
+  for (const { package, properties } of destructured) {
+    for (const prop of properties) {
+      lines = lines.map(l => l.match(/\s*\*/) ? l : l.replaceAll(re(prop), `import('${package}').${prop}`))
+    }
+  }
+  return lines.join('\n')
+}
+
 ;(async () => {
 
   const rollupFile = './dist/cds-types.d.ts'
   let rollup = (await readFile(rollupFile)).toString()
+
+  rollup = replaceImports(rollup)
 
   // fix `delete` keyword as const - api-extractor does not support it
   rollup = rollup
@@ -26,8 +81,7 @@ const { readFile, writeFile } = require('fs/promises')
 
   // put all exports into an augmented module declaration. Remove all "declare" modifiers
   // as they will now already be in an ambient context
-  rollup = rollup
-    .replaceAll('declare ','')
+  //rollup = rollup.replaceAll('declare ','')
   rollup = `declare module '@sap/cds' {\n${rollup}\n}`
 
   await writeFile(rollupFile, rollup)

--- a/.github/rollup-patch.js
+++ b/.github/rollup-patch.js
@@ -33,7 +33,7 @@ function _getImports (src) {
  * @param {string} src 
  */
 function replaceImports (src) {
-  const re = id => new RegExp(`\\b${id}\\b(?!\\?|:)`, 'g')  // match whole word, but not if it's a type assertion (x?: T)
+  const re = id => new RegExp(`\\b${id}\\b(?!\\?|:)`, 'g')  // match whole word, but only if it's a type assertion (x?: T)
   const { named, destructured } = _getImports(src)
 
   function replace (l, what, wth) {

--- a/.github/rollup-patch.js
+++ b/.github/rollup-patch.js
@@ -24,6 +24,12 @@ const { readFile, writeFile } = require('fs/promises')
     rollup += filterFile
   }
 
+  // put all exports into an augmented module declaration. Remove all "declare" modifiers
+  // as they will now already be in an ambient context
+  rollup = rollup
+    .replaceAll('declare ','')
+  rollup = `declare module '@sap/cds' {\n${rollup}\n}`
+
   await writeFile(rollupFile, rollup)
 
 })()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Version 0.6.0 - TBD
+## Version 0.6.0 - 2024-07-05
+This is a prerelease version (`next`) as a preview for the upcoming release of cds 8.
 ### Changed
 - Wrapped all types into an augmented module declaration for `@sap/cds`.
+- Added a postinstall script to symlink `@cap-js/cds-types` to `@types/sap__cds` to benefit from the default type resolution mechanism employed by Definitely Typed.
 
 ## Version 0.5.0 - 2024-06-20
 This is a prerelease version (`next`) as a preview for the upcoming release of cds 8.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.6.0 - TBD
+### Changed
+- Wrapped all types into an augmented module declaration for `@sap/cds`.
 
 ## Version 0.5.0 - 2024-06-20
 This is a prerelease version (`next`) as a preview for the upcoming release of cds 8.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "typings": "apis/cds.d.ts",
   "files": [
     "dist/",
+    "scripts/",
     "LICENSE",
     "README.md"
   ],
@@ -26,10 +27,11 @@
     "lint": "npx eslint .",
     "lint:fix": "npx eslint . --fix",
     "setup": "npm i && npm i file:. --no-save --force",
-    "prerelease:ci-fix": ".github/prerelease-fix.js"
+    "prerelease:ci-fix": ".github/prerelease-fix.js",
+    "postinstall": "./scripts/postinstall.js"
   },
   "peerDependencies": {
-    "@sap/cds": ">=7 || ^8.0.0-beta"
+    "@sap/cds": "^8.0.0"
   },
   "dependencies": {
     "@types/express": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/cds-types",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Type definitions for main packages of CAP, like `@sap/cds`",
   "repository": "github:cap-js/cds-types",
   "homepage": "https://cap.cloud.sap/",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+/* eslint-disable @typescript-eslint/no-var-requires*/
+/* eslint-disable no-undef */
+const fs = require('node:fs')
+const { join } = require('node:path')
+
+if (!process.env.INIT_CWD) return
+// TODO: check if were in a local install
+const nodeModules = join(process.env.INIT_CWD, 'node_modules')
+if (!fs.existsSync(nodeModules)) return
+const typesDir = join(nodeModules, '@types')
+if (!fs.existsSync(typesDir)) fs.mkdirSync(typesDir)
+fs.symlink(join(nodeModules, '@cap-js', 'cds-types'), join(typesDir, 'sap__cds'), () => {})

--- a/test/typescript/apis/project/cds-env.ts
+++ b/test/typescript/apis/project/cds-env.ts
@@ -1,4 +1,4 @@
-import { env } from '../../../..'
+import { env } from '@sap/cds'
 
 env.folders.db = ''
 env.folders.srv = ''

--- a/test/typescript/apis/project/cds-linked.ts
+++ b/test/typescript/apis/project/cds-linked.ts
@@ -1,6 +1,6 @@
 import { LinkedCSN } from '../../../../apis/linked';
 import { _ArrayLike } from '../../../../apis/internal/util';
-import cds from '../../../..';
+import cds from '@sap/cds';
 import { csn } from '../../../..';
 import { as } from './dummy';
 

--- a/test/typescript/apis/project/cds-server.ts
+++ b/test/typescript/apis/project/cds-server.ts
@@ -1,4 +1,4 @@
-import cds from '../../../..'
+import cds from '@sap/cds'
 import express from 'express'
 
 const h = undefined as unknown as express.RequestHandler

--- a/test/typescript/apis/project/cds.ts
+++ b/test/typescript/apis/project/cds.ts
@@ -1,4 +1,4 @@
-import cds from '../../../../';
+import cds from '@sap/cds';
 
 cds.version === '1.2.3'
 cds.home === 'path/to/cds'


### PR DESCRIPTION
Add patch step to wrap resulting rollup file into

```ts
declare module '@sap/cds' {
  …
}
```

and remove all `declare` keywords therein. The latter is required as the module declaration opens an ambient context which can not be nested. api-extractor does not seem to support[^1][^2] this feature natively as of today.

The rollup patch also removes all `import … from …` statements and replaces them with [type imports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html#import-types). Having module level imports would automatically cause TS to consider the file a module, and modules can not do the global type augmentation we want to have.

With this change in place, the TS LSP should be able to detect our type definitions once they are present in a user project, without having to be shipped and proxied through our implementation.

[^1]: https://github.com/microsoft/rushstack/issues/2090
[^2]: https://github.com/microsoft/rushstack/issues/1709