### PR TITLE
Add postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "typings": "apis/cds.d.ts",
   "files": [
     "dist/",
+    "scripts/",
     "LICENSE",
     "README.md"
   ],
@@ -26,10 +27,11 @@
     "lint": "npx eslint .",
     "lint:fix": "npx eslint . --fix",
     "setup": "npm i && npm i file:. --no-save --force",
-    "prerelease:ci-fix": ".github/prerelease-fix.js"
+    "prerelease:ci-fix": ".github/prerelease-fix.js",
+    "postinstall": "./scripts/postinstall.js"
   },
   "peerDependencies": {
-    "@sap/cds": ">=7 || ^8.0.0-beta"
+    "@sap/cds": "^8.0.0"
   },
   "dependencies": {
     "@types/express": "^4.17.21"

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+/* eslint-disable @typescript-eslint/no-var-requires*/
+/* eslint-disable no-undef */
+const fs = require('node:fs')
+const { join } = require('node:path')
+
+if (!process.env.INIT_CWD) return
+// TODO: check if were in a local install
+const nodeModules = join(process.env.INIT_CWD, 'node_modules')
+if (!fs.existsSync(nodeModules)) return
+const typesDir = join(nodeModules, '@types')
+if (!fs.existsSync(typesDir)) fs.mkdirSync(typesDir)
+fs.symlink(join(nodeModules, '@cap-js', 'cds-types'), join(typesDir, 'sap__cds'), () => {})


### PR DESCRIPTION
Global augmentations are not found by the LSP unless they are put into `@types`. One possible route is to symlink `@types/sap__cds` to `@cap-js/cds-types`.