### PR TITLE
fix(postinstall): create symlink as junction on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 0.7.0 - TBD
+This is a prerelease version (`next`) as a preview for the upcoming release of cds 8.
+### Fixed
+- Scripts `postinstall` and `prerelease:ci-fix` now work correctly on windows.
+
 ## Version 0.6.0 - 2024-07-05
 This is a prerelease version (`next`) as a preview for the upcoming release of cds 8.
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Version 0.7.0 - TBD
+## Version 0.6.1 - TBD
 ### Fixed
 - Scripts `postinstall` and `prerelease:ci-fix` now work correctly on windows.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.7.0 - TBD
-This is a prerelease version (`next`) as a preview for the upcoming release of cds 8.
 ### Fixed
 - Scripts `postinstall` and `prerelease:ci-fix` now work correctly on windows.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/cds-types",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Type definitions for main packages of CAP, like `@sap/cds`",
   "repository": "github:cap-js/cds-types",
   "homepage": "https://cap.cloud.sap/",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "lint": "npx eslint .",
     "lint:fix": "npx eslint . --fix",
     "setup": "npm i && npm i file:. --no-save --force",
-    "prerelease:ci-fix": ".github/prerelease-fix.js",
-    "postinstall": "./scripts/postinstall.js"
+    "prerelease:ci-fix": "node .github/prerelease-fix.js",
+    "postinstall": "node ./scripts/postinstall.js"
   },
   "peerDependencies": {
     "@sap/cds": "^8.0.0"

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -3,7 +3,10 @@
 /* eslint-disable @typescript-eslint/no-var-requires*/
 /* eslint-disable no-undef */
 const fs = require('node:fs')
+const { platform } = require('node:os')
 const { join } = require('node:path')
+
+const IS_WIN = platform() === 'win32'
 
 if (!process.env.INIT_CWD) return
 // TODO: check if were in a local install
@@ -11,4 +14,5 @@ const nodeModules = join(process.env.INIT_CWD, 'node_modules')
 if (!fs.existsSync(nodeModules)) return
 const typesDir = join(nodeModules, '@types')
 if (!fs.existsSync(typesDir)) fs.mkdirSync(typesDir)
-fs.symlink(join(nodeModules, '@cap-js', 'cds-types'), join(typesDir, 'sap__cds'), () => {})
+
+fs.symlinkSync(join(nodeModules, '@cap-js/cds-types'), join(typesDir, 'sap__cds'), IS_WIN ? 'junction' : undefined)


### PR DESCRIPTION
* fs.symlinkSync needs parameter `junction` on windows if run in non admin (not elevated) shell
* test will follow