### PR TITLE
Create relative symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## Version 0.6.1 - TBD
 ### Fixed
 - Scripts `postinstall` and `prerelease:ci-fix` now work correctly on windows.
+- `postinstall` script now creates a relative symlink from `@types/sap__cds` to allow the project to be moved/ renamed.
 
 ## Version 0.6.0 - 2024-07-05
 This is a prerelease version (`next`) as a preview for the upcoming release of cds 8.

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -4,7 +4,7 @@
 /* eslint-disable no-undef */
 const fs = require('node:fs')
 const { platform } = require('node:os')
-const { join } = require('node:path')
+const { join, relative, dirname } = require('node:path')
 
 const IS_WIN = platform() === 'win32'
 
@@ -15,4 +15,8 @@ if (!fs.existsSync(nodeModules)) return
 const typesDir = join(nodeModules, '@types')
 if (!fs.existsSync(typesDir)) fs.mkdirSync(typesDir)
 
-fs.symlinkSync(join(nodeModules, '@cap-js/cds-types'), join(typesDir, 'sap__cds'), IS_WIN ? 'junction' : undefined)
+// use a relative target, in case the user moves the project
+const target = join(typesDir, 'sap__cds')
+const src = join(nodeModules, '@cap-js/cds-types')
+const rel = relative(dirname(target), src) // need dirname or we'd land one level above node_modules (one too many "../")
+fs.symlinkSync(rel, target, IS_WIN ? 'junction' : undefined)


### PR DESCRIPTION
Symlink `<project path>/node_modules/@cap-js/cds-types` -> `../@types/sap__cds` to allow users to move/ rename their project without the symlink breaking.