### PR TITLE
fix(postinstall): unlink before link sap__cds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Version 0.7.0 - TBD
+## Version 0.6.2 - TBD
+### Fixed
+- Symlink `@types/sap__cds` correctly created in case of upgrading `@cap-js/cds-types`.
 
 ## Version 0.6.1 - 2024-07-18
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cap-js/cds-types",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cap-js/cds-types",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/cds-types",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Type definitions for main packages of CAP, like `@sap/cds`",
   "repository": "github:cap-js/cds-types",
   "homepage": "https://cap.cloud.sap/",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -17,5 +17,12 @@ const target = join(typesDir, 'sap__cds')
 const src = join(nodeModules, '@cap-js/cds-types')
 const rel = relative(dirname(target), src) // need dirname or we'd land one level above node_modules (one too many "../")
 
+// remove the existing symlink
+try {
+    fs.unlinkSync(target)
+} catch {
+    // symlink did not exist, continue
+}
+
 // 'junction' is needed to make it work on windows, others ignore
 fs.symlinkSync(rel, target, 'junction')


### PR DESCRIPTION
remove existing potentially different symlink before creating the new one