### PR TITLE
Do not fail if symlink exists

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -24,5 +24,10 @@ try {
     // symlink did not exist, continue
 }
 
-// 'junction' is needed to make it work on windows, others ignore
-fs.symlinkSync(rel, target, 'junction')
+try {
+    // 'junction' is needed to make it work on windows, others ignore
+    fs.symlinkSync(rel, target, 'junction')
+} catch (e) {
+    if (e.code !== 'EEXIST') throw e
+    // else: symlink exists (the previous unlink hasn't worked), ignore
+}


### PR DESCRIPTION
Stack traces from customers indicate that `symLink()` fails with `EEXIST`, which would mean it wasn't deleted by the previous `unlinkSync`.

```
npm ERR! Error: EEXIST: file already exists, symlink '../@cap-js/cds-types' -> '/tmp/app/node_modules/@types/sap__cds' (STDOUT, STG)#
npm ERR!     at Object.symlinkSync (node:fs:1810:11) (STDOUT, STG)#
npm ERR!     at Object.<anonymous> (/tmp/app/node_modules/@cap-js/cds-types/scripts/postinstall.js:28:4) (STDOUT, STG)#
```

Fix is to ignore `EEXIST` errors.
