### PR TITLE
Allow `connect.to (ServiceClass)` as alternative to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## Version 0.7.0 - TBD
 ### Added
 - `Service.emit(...)` can now also be called with custom events
+- `connect.to (ServiceClass)` as alternative to `'service'` string
+- `connect.to ('db')` returning `cds.DatabaseService`
 
 ## Version 0.6.3 - 2024-07-19
 ### Fixed

--- a/apis/server.d.ts
+++ b/apis/server.d.ts
@@ -12,12 +12,27 @@ export const connect: {
 
   /**
 		 * Connects to a specific datasource.
+		 * @example cds.connect.to ('service')
 		 * @see [capire](https://cap.cloud.sap/docs/node.js/cds-connect#cds-connect-to)
 		 */
   to(datasource: string, options?: cds_connect_options): Promise<Service>,
 
   /**
+	 * Shortcut for 'db' as the primary database returning `cds.DatabaseService`
+	 * @example cds.connect.to ('db')
+	*/
+  to(datasource: 'db', options?: cds_connect_options): Promise<cds.DatabaseService>,
+
+  /**
+	 * Connects to a specific datasource via a Service subclass
+	 * @example cds.connect.to (ServiceClass)
+	 * @see [capire](https://cap.cloud.sap/docs/node.js/cds-connect#cds-connect-to)
+	 */
+  to<S extends Service>(datasource: {new(): S}, options?: cds_connect_options): Promise<S>,
+
+  /**
 		 * Connects to a specific datasource via options.
+		 * @example cds.connect.to ({ kind:..., impl:... })
 		 * @see [capire](https://cap.cloud.sap/docs/node.js/cds-connect#cds-connect-to)
 		 */
   to(options: cds_connect_options): Promise<Service>,

--- a/test/typescript/apis/project/cds-services.ts
+++ b/test/typescript/apis/project/cds-services.ts
@@ -1,4 +1,4 @@
-import cds, { TypedRequest } from '@sap/cds'
+import cds, { Service, TypedRequest } from '@sap/cds'
 import { Foo, Foos, action } from './dummy'
 const model = cds.reflect({})
 const { Book: Books } = model.entities
@@ -12,6 +12,9 @@ cds.connect.to('auth', {impl: ''})
 cds.connect.to('auth', {service: 'BusinessPartnerService'})
 cds.connect.to({kind: 'odata', model:'some/imported/model', service: 'BusinessPartnerService' })
 cds.connect.to({ kind:'sqlite', credentials:{database:'my.db'} })
+cds.connect.to(class CustomService extends Service {}) // cds-typer scenario
+const dbSrv = await cds.connect.to('db')
+dbSrv.deploy() // only valid if it's a DatabaseService
 
 // legacy
 cds.connect('db')


### PR DESCRIPTION
Allows cds-typer to provide typed methods for actions:
```ts
import Remote from '#cds-models/remote'
const remote = await cds.connect.to(Remote)
await remote.some_action(arg1, arg2, ...)
// or
await remote.some_action({ arg1, arg2, ... })
```

Also add convenience `.to('db')` returning [`cds.DatabaseService`](https://cap.cloud.sap/docs/node.js/databases).