### PR TITLE
CSN is also a valid option for model to connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 - Most `cds.requires` entries are now optionals.
-- It is possible to connect with CSN model
+- `cds.connect.to` now also supports using a precompiled model.
 
 ## Version 0.6.5 - 2024-08-13
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 - Most `cds.requires` entries are now optionals.
+- It is possible to connect with CSN model
 
 ## Version 0.6.5 - 2024-08-13
 ### Fixed

--- a/apis/server.d.ts
+++ b/apis/server.d.ts
@@ -154,7 +154,7 @@ interface cds_connect_options {
   impl?: string
   service?: string
   kind?: string
-  model?: string
+  model?: string | CSN
   credentials?: object
 }
 


### PR DESCRIPTION
I use a preloaded model to connect to the database and it works. However TS doesn't allow  to use. This PR fixes it.
```ts
  const model = await cds.load('models/public');
 const db = await cds.connect.to('db', {
    model: model as any,
    kind: 'hana',
    credentials: requires?.db?.credentials,
  });
```
