### PR TITLE
Deep Required Projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 - The CQL methods `.where` and `.having` now suggest property names for certain overloads.
 
+### Changed
+- Properties of entities are no longer optional in projections, eliminating the need to perform optional chaining on them when using nested projections
 
 ## Version 0.6.5 - 2024-08-13
 ### Fixed

--- a/apis/internal/query.d.ts
+++ b/apis/internal/query.d.ts
@@ -3,7 +3,7 @@ import type { entity } from '../linked/classes'
 import type { column_expr } from '../cqn'
 import type { ArrayConstructable, Constructable, SingularInstanceType, Unwrap, UnwrappedInstanceType } from './inference'
 import { ConstructedQuery } from '../ql'
-import { KVPairs } from './util'
+import { KVPairs, DeepRequired } from './util'
 
 // https://cap.cloud.sap/docs/node.js/cds-ql?q=projection#projection-functions
 type Projection<T> = (e: QLExtensions<T extends ArrayConstructable ? SingularInstanceType<T> : T>) => void
@@ -161,7 +161,7 @@ export interface InUpsert<T> {
 }
 
 // don't wrap QLExtensions in more QLExtensions (indirection to work around recursive definition)
-export type QLExtensions<T> = T extends QLExtensions_<any> ? T : QLExtensions_<T>
+export type QLExtensions<T> = T extends QLExtensions_<any> ? T : QLExtensions_<DeepRequired<T>>
 
 /**
  * QLExtensions are properties that are attached to entities in CQL contexts.

--- a/apis/internal/util.d.ts
+++ b/apis/internal/util.d.ts
@@ -27,3 +27,10 @@ type KVPairs<T,K,V> = T extends []
   : T extends [K, V, ...infer R]
     ? KVPairs<R,K,V>
     : false
+
+/**
+ * Recursively excludes nullability from all properties of T.
+ */
+export type DeepRequired<T> = { 
+  [K in keyof T]: DeepRequired<T[K]>
+} & Exclude<Required<T>, null>

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -41,12 +41,13 @@ SELECT.from(Foos).where('fn(x) = ', 42)
 sel.from(Foos).columns('y')
 sel.from(Foo).columns('y')
 sel.columns("y")
+SELECT.from(Foos, f => f.ref(r => r.x))  // ref should be callable without optional chaining (DeepRequired)
 
 SELECT.from(Foos).orderBy('x')  // x auto completed
 SELECT.from(Foos).orderBy('y')  // non-columns also still possible
 
 SELECT.from(Foos, f => { 
-    f.name,
+    f.x,
     // @ts-expect-error - foobar is not a valid column
     f.foobar
 })


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-types/issues/223

Makes properties of entities recursively required in projections. This eliminates the need to perform optional chaining within projections, which [throw off the runtime](https://github.com/cap-js/cds-types/issues/223#issuecomment-2348286232):

```patch
SELECT.from(Books, b => 
-  b.author?.(a => a.name)
+  b.author(a => a.name)
)



