### PR TITLE
Type MTX services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - `cds.cli` CLI arguments
 - `cds.requires` types for MTX services.
 
+### Changed
+- Most `cds.requires` entries are now optionals.
+
 ## Version 0.6.5 - 2024-08-13
 ### Fixed
 - The `@types/sap__cds` link created by the `postinstall` script now also works in monorepo setups where the target `@cap-js/cds-types` might already be preinstalled (often hoisted some levels up).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 - `cds.app` typed as express.js application
 - `cds.cli` CLI arguments
+- `cds.requires` types for MTX services.
 
 ## Version 0.6.5 - 2024-08-13
 ### Fixed

--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -87,7 +87,6 @@ export namespace env {
       alwaysUpgradeModel?: boolean,
       [key: string]: any,
     },
-
     'cds.xt.SmsProvisioningService'?: {
       model: string,
       kind: string,
@@ -95,8 +94,6 @@ export namespace env {
     },
     'cds.xt.ExtensibilityService'?: {
       model: string,
-      'namespace-blocklist': string[],
-      'extension-allowlist': { for: string[], 'new-entities'?: number }[],
       [key: string]: any,
     },
     'cds.xt.ModelProviderService'?: {

--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -64,21 +64,49 @@ export namespace env {
       binding?: Binding,
       [key: string]: any,
     },
-    multitenancy: boolean | { kind: string, jobs: {
+    multitenancy?: boolean | { kind: string, jobs: {
       clusterSize: number,
       workerSize: number,
       t0: string,
       [key: string]: any,
     },},
-    toggles: boolean,
-    extensibility: boolean | {
+    toggles?: boolean,
+    extensibility?: boolean | {
       model: string[],
       tenantCheckInterval: number,
       [key: string]: any,
     },
-    messaging: {
+    messaging?: {
       kind: 'file-based-messaging' | 'redis-messaging' | 'local-messaging' | 'enterprise-messaging' | 'enterprise-messaging-shared' | string,
       format: 'cloudevents' | string,
+      [key: string]: any,
+    },
+    'cds.xt.SaasProvisioningService'?: {
+      model: string,
+      kind: string,
+      alwaysUpgradeModel: boolean,
+      [key: string]: any,
+    },
+
+    'cds.xt.SmsProvisioningService'?: {
+      model: string,
+      kind: string,
+      dependencies: string[],
+      [key: string]: any,
+    },
+    'cds.xt.ExtensibilityService'?: {
+      model: string,
+      'namespace-blocklist': string[],
+      'extension-allowlist': { for: string[], 'new-entities'?: number }[],
+      [key: string]: any,
+    },
+    'cds.xt.ModelProviderService'?: {
+      model: string,
+      root: string,
+      [key: string]: any,
+    },
+    'cds.xt.DeploymentService'?: {
+      model: string,
       [key: string]: any,
     },
     [key: string]: any,

--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -84,14 +84,13 @@ export namespace env {
     'cds.xt.SaasProvisioningService'?: {
       model: string,
       kind: string,
-      alwaysUpgradeModel: boolean,
+      alwaysUpgradeModel?: boolean,
       [key: string]: any,
     },
 
     'cds.xt.SmsProvisioningService'?: {
       model: string,
       kind: string,
-      dependencies: string[],
       [key: string]: any,
     },
     'cds.xt.ExtensibilityService'?: {

--- a/apis/utils.d.ts
+++ b/apis/utils.d.ts
@@ -1,7 +1,7 @@
 import type * as fs from 'node:fs'
 
 /**
- * Provides a set of utility functionss
+ * Provides a set of utility functions
  */
 declare const utils: {
 

--- a/test/typescript/apis/project/cds-env.ts
+++ b/test/typescript/apis/project/cds-env.ts
@@ -39,7 +39,6 @@ env.requires['cds.xt.ModelProviderService'] = { model: '@sap/cds-mtxs/srv/model-
 env.requires['cds.xt.DeploymentService'] = { model: '@sap/cds-mtxs/srv/deployment-service' }
 
 env.requires.multitenancy = { kind: 'shared', jobs: { clusterSize:1, workerSize:1, t0:'', foo:'' }}
-env.requires.multitenancy = { kind: 'shared', jobs: { clusterSize:1, workerSize:1, t0:'', foo:'' }}
 env.requires.messaging = { kind: '', format: '', foo: '' }
 
 env.foo = {}

--- a/test/typescript/apis/project/cds-env.ts
+++ b/test/typescript/apis/project/cds-env.ts
@@ -25,6 +25,18 @@ env.requires.auth.users!.TEST = {}
 env.requires.db.kind = 'hana'
 env.requires.db.binding!.key = 'cf'
 
+env.requires['cds.xt.SaasProvisioningService'] = { kind: 'saas-registry', model: '@sap/cds-mtxs/srv/cf/saas-provisioning-service' }
+env.requires['cds.xt.SmsProvisioningService'] = { kind: 'subscription-manager', model: '@sap/cds-mtxs/srv/cf/sms-provisioning-service' }
+env.requires['cds.xt.ExtensibilityService'] = {
+  model: '@sap/cds-mtxs/srv/extensibility-service',
+  'namespace-blocklist': ['sap', 'sap.*', 'sap.*.*'],
+  'extension-allowlist': [
+    { for: [ 'CatalogService' ], 'new-entities': 10 },
+    { for: [ '*' ] }
+  ],
+}
+
+env.requires.multitenancy = { kind: 'shared', jobs: { clusterSize:1, workerSize:1, t0:'', foo:'' }}
 env.requires.multitenancy = { kind: 'shared', jobs: { clusterSize:1, workerSize:1, t0:'', foo:'' }}
 env.requires.messaging = { kind: '', format: '', foo: '' }
 

--- a/test/typescript/apis/project/cds-env.ts
+++ b/test/typescript/apis/project/cds-env.ts
@@ -35,6 +35,8 @@ env.requires['cds.xt.ExtensibilityService'] = {
     { for: [ '*' ] }
   ],
 }
+env.requires['cds.xt.ModelProviderService'] = { model: '@sap/cds-mtxs/srv/model-provider', _in_sidecar: true, root: '../..' }
+env.requires['cds.xt.DeploymentService'] = { model: '@sap/cds-mtxs/srv/deployment-service' }
 
 env.requires.multitenancy = { kind: 'shared', jobs: { clusterSize:1, workerSize:1, t0:'', foo:'' }}
 env.requires.multitenancy = { kind: 'shared', jobs: { clusterSize:1, workerSize:1, t0:'', foo:'' }}

--- a/test/typescript/apis/project/cds-env.ts
+++ b/test/typescript/apis/project/cds-env.ts
@@ -27,14 +27,7 @@ env.requires.db.binding!.key = 'cf'
 
 env.requires['cds.xt.SaasProvisioningService'] = { kind: 'saas-registry', model: '@sap/cds-mtxs/srv/cf/saas-provisioning-service' }
 env.requires['cds.xt.SmsProvisioningService'] = { kind: 'subscription-manager', model: '@sap/cds-mtxs/srv/cf/sms-provisioning-service' }
-env.requires['cds.xt.ExtensibilityService'] = {
-  model: '@sap/cds-mtxs/srv/extensibility-service',
-  'namespace-blocklist': ['sap', 'sap.*', 'sap.*.*'],
-  'extension-allowlist': [
-    { for: [ 'CatalogService' ], 'new-entities': 10 },
-    { for: [ '*' ] }
-  ],
-}
+env.requires['cds.xt.ExtensibilityService'] = { model: '@sap/cds-mtxs/srv/extensibility-service' }
 env.requires['cds.xt.ModelProviderService'] = { model: '@sap/cds-mtxs/srv/model-provider', _in_sidecar: true, root: '../..' }
 env.requires['cds.xt.DeploymentService'] = { model: '@sap/cds-mtxs/srv/deployment-service' }
 


### PR DESCRIPTION
When we document the MTX services in such detail (e.g. https://cap.cloud.sap/docs/guides/multitenancy/mtxs#modelproviderservice), we can also provide types for them.
