### PR TITLE
Add optional `kind` to MTX services

### DIFF
--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -94,15 +94,18 @@ export namespace env {
     },
     'cds.xt.ExtensibilityService'?: {
       model: string,
+      kind?: string,
       [key: string]: any,
     },
     'cds.xt.ModelProviderService'?: {
       model: string,
       root: string,
+      kind?: string,
       [key: string]: any,
     },
     'cds.xt.DeploymentService'?: {
       model: string,
+      kind?: string,
       [key: string]: any,
     },
     [key: string]: any,


### PR DESCRIPTION
Continued from https://github.com/cap-js/cds-types/pull/253:

So apparently it's possible to set a `kind` like `{ kind: 'rest' }` to override the protocol of the service via configuration (never seen anyone do that though).

Therefore the right solution would be to add it as an optional string, as it's `undefined` by default.