### PR TITLE
feat: add `profiles` to `cds.env`

### DIFF
--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -13,6 +13,7 @@ export const env: {
     folders: string[],
     [key: string]: any,
   },
+  profiles: string[],
   requires: env.Requires,
   folders: {
     app: string,

--- a/test/typescript/apis/project/cds-env.ts
+++ b/test/typescript/apis/project/cds-env.ts
@@ -31,6 +31,9 @@ env.requires['cds.xt.ExtensibilityService'] = { model: '@sap/cds-mtxs/srv/extens
 env.requires['cds.xt.ModelProviderService'] = { model: '@sap/cds-mtxs/srv/model-provider', _in_sidecar: true, root: '../..' }
 env.requires['cds.xt.DeploymentService'] = { model: '@sap/cds-mtxs/srv/deployment-service' }
 
+env.profiles.includes("development")
+env.profiles.length > 2
+
 env.requires.multitenancy = { kind: 'shared', jobs: { clusterSize:1, workerSize:1, t0:'', foo:'' }}
 env.requires.messaging = { kind: '', format: '', foo: '' }
 


### PR DESCRIPTION
Adds missing `profiles` property to `cds.env` type