### PR TITLE
chore: Deprecating cds.lazify

### DIFF
--- a/apis/core.d.ts
+++ b/apis/core.d.ts
@@ -32,34 +32,11 @@ export function extend<T> (target: T): {
 }
 
 /**
- * Equip a given facade object with getters for lazy-loading modules instead
- * of static requires. Example:
- *
- * @example
- * ```js
- *    const facade = lazify ({
- *       sub: lazy => require ('./sub-module')
- *    })
- * ```
- *
- * The first usage of `facade.sub` will load the sub module
- * using standard Node.js's `module.require` functions.
+ * @deprecated since version 8.1
  */
 export function lazify<T> (target: T): T
 
 /**
- * Prepare a node module for lazy-loading submodules instead
- * of static requires. Example:
- *
- * @example
- * ```js
- *    require = lazify (module) //> turns require into a lazy one
- *    const facade = module.exports = {
- *       sub: require ('./sub-module')
- *    })
- * ```
- *
- * The first usage of `facade.sub` will load the sub module
- * using standard Node.js's `module.require` functions.
+ * @deprecated since version 8.1
  */
 export function lazified<T> (target: T): T

--- a/test/typescript/apis/project/cds-core.ts
+++ b/test/typescript/apis/project/cds-core.ts
@@ -4,12 +4,6 @@ const x = cds.extend({ a: 42 }).with({ b: 'hello world' })
 const a: number = x.a
 const b: string = x.b
 
-const l1 = cds.lazify({x: 42})
-l1.x
-
-const l2 = cds.lazified({x: 42})
-l2.x
-
 const e: cds.entity = new cds.entity
 e.drafts
 cds.entity === cds.builtin.classes.entity

--- a/test/typescript/runtime.test.ts
+++ b/test/typescript/runtime.test.ts
@@ -81,7 +81,7 @@ describe('runtime tests', () => {
     let foo = cds.extend({foo:1}).with({bar:2},{car:3})
     foo.foo
     foo.bar
-    
+
     // FIXME: broke after 0.6.3 in CI, but works locally, renable asap
     //cds.model = cds.linked({})
     {
@@ -159,8 +159,6 @@ describe('runtime tests', () => {
         test,
         log,
         debug,
-        lazify,
-        lazified,
         // clone,
         exit,
 


### PR DESCRIPTION
We'll be deprecating `cds.lazify` in an upcoming release.