### PR TITLE
feat: allow srv handler registration for array of typed entities

### DIFF
--- a/apis/services.d.ts
+++ b/apis/services.d.ts
@@ -224,8 +224,8 @@ export class Service extends QueryAPI {
   // Provider API
   prepend (fn: ServiceImpl): this
 
-  on<T extends ArrayConstructable>(eve: types.event, entity: T, handler: CRUDEventHandler.On<Unwrap<T>>): this
-  on<T extends Constructable>(eve: types.event, entity: T, handler: CRUDEventHandler.On<InstanceType<T>>): this
+  on<T extends ArrayConstructable>(eve: types.event, entity: T | T[], handler: CRUDEventHandler.On<Unwrap<T>>): this
+  on<T extends Constructable>(eve: types.event, entity: T | T[], handler: CRUDEventHandler.On<InstanceType<T>>): this
   on<F extends CdsFunction>(boundAction: F, service: string, handler: ActionEventHandler<F['__parameters'], void | Error | F['__returns']>): this
   on<F extends CdsFunction>(unboundAction: F, handler: ActionEventHandler<F['__parameters'], void | Error | F['__returns']>): this
   on (eve: types.event, entity: types.target, handler: OnEventHandler): this
@@ -238,8 +238,8 @@ export class Service extends QueryAPI {
   // onFailed (eve: types.Events, handler: types.EventHandler): this
   before<F extends CdsFunction>(boundAction: F, service: string, handler: CRUDEventHandler.Before<F['__parameters'], void | Error | F['__returns']>): this
   before<F extends CdsFunction>(unboundAction: F, handler: CRUDEventHandler.Before<F['__parameters'], void | Error | F['__returns']>): this
-  before<T extends ArrayConstructable>(eve: types.event, entity: T, handler: CRUDEventHandler.Before<Unwrap<T>>): this
-  before<T extends Constructable>(eve: types.event, entity: T, handler: CRUDEventHandler.Before<InstanceType<T>>): this
+  before<T extends ArrayConstructable>(eve: types.event, entity: T | T[], handler: CRUDEventHandler.Before<Unwrap<T>>): this
+  before<T extends Constructable>(eve: types.event, entity: T | T[], handler: CRUDEventHandler.Before<InstanceType<T>>): this
   before (eve: types.event, entity: types.target, handler: EventHandler): this
   before (eve: types.event, handler: EventHandler): this
 
@@ -248,11 +248,11 @@ export class Service extends QueryAPI {
   // (3) check if T is scalar -> use T directly
   // this streamlines that in _most_ cases, handlers will receive a single object.
   // _Except_ for after.read handlers (1), which will change its inflection based on T.
-  after<T extends ArrayConstructable>(event: 'READ', entity: T, handler: CRUDEventHandler.After<InstanceType<T>>): this
-  after<T extends ArrayConstructable>(event: 'each', entity: T, handler: CRUDEventHandler.After<Unwrap<T>>): this
-  after<T extends Constructable>(event: 'READ' | 'each', entity: T, handler: CRUDEventHandler.After<InstanceType<T>>): this
-  after<T extends ArrayConstructable>(eve: types.event, entity: T, handler: CRUDEventHandler.After<Unwrap<T>>): this
-  after<T extends Constructable>(eve: types.event, entity: T, handler: CRUDEventHandler.After<InstanceType<T>>): this
+  after<T extends ArrayConstructable>(event: 'READ', entity: T | T[], handler: CRUDEventHandler.After<InstanceType<T>>): this
+  after<T extends ArrayConstructable>(event: 'each', entity: T | T[], handler: CRUDEventHandler.After<Unwrap<T>>): this
+  after<T extends Constructable>(event: 'READ' | 'each', entity: T | T[], handler: CRUDEventHandler.After<InstanceType<T>>): this
+  after<T extends ArrayConstructable>(eve: types.event, entity: T | T[], handler: CRUDEventHandler.After<Unwrap<T>>): this
+  after<T extends Constructable>(eve: types.event, entity: T | T[], handler: CRUDEventHandler.After<InstanceType<T>>): this
   after<F extends CdsFunction>(boundAction: F, service: string, handler: CRUDEventHandler.After<F['__parameters'], void | Error | F['__returns']>): this
   after<F extends CdsFunction>(unboundAction: F, handler: CRUDEventHandler.After<F['__parameters'], void | Error | F['__returns']>): this
   after (eve: types.event, entity: types.target, handler: ResultsHandler): this

--- a/test/typescript/apis/project/dummy.ts
+++ b/test/typescript/apis/project/dummy.ts
@@ -12,6 +12,13 @@ export class Foo {
 
 export class Foos extends Array<Foo> { static readonly drafts: typeof Foo }
 
+export class Bar {
+  static readonly drafts: typeof Bar
+  name: string = "bar"
+}
+
+export class Bars extends Array<Bar> { static readonly drafts: typeof Foo }
+
 
 // for bound/ unbound actions
 export const action = ((foo: Foo) => 42) as Action


### PR DESCRIPTION
As per CAP documentation the handler registration methods have the following signature

```js
function srv.on/before/after (
  event   : string | string[] | '*',
  entity? : CSN definition | CSN definition[] | string | string[] | '*',
  handler : function
)
```

which should allow the following registrations ...

```ts
import { Books, Authors } from "#cds-models/CatalogService";

srv.before("READ", [Books, Authors], (req) => { ... }
srv.on("READ", [Books, Authors], (req) => { ... }
srv.after("READ", [Books, Authors], (data) => { ... }
```
but fails with compiler errors.

This PR enables the array option for generated cds-typer classes as well