### PR TITLE
fix: fixes issues in ql SELECT.from(...) when using typer classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Added missing type for `cds.context.model`
 - Added missing type for `req.query.elements`
 - Made constructors for query parts (`SELECT`, `UPDATE`, `DELETE`, ...) private, as they should only be accessed statically
+- `SELECT` returns a single instance now when specifying a primary key
 
 ### Added
 - `cds.app` typed as express.js application

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -164,7 +164,7 @@ type SELECT_from =
     entityType: T,
     primaryKey: PK,
     columns: string[]  // could be keyof in the future
-  ) => Awaitable<SELECT<PluralInstanceType<T>>, PluralInstanceType<T>>)
+  ) => Awaitable<SELECT<InstanceType<T>>, InstanceType<T>>)
   & (<T extends Constructable>(
     entityType: T,
     projection?: Projection<InstanceType<T>>
@@ -173,7 +173,7 @@ type SELECT_from =
     entityType: T,
     primaryKey: PK,
     projection?: Projection<InstanceType<T>>
-  ) => Awaitable<SELECT<PluralInstanceType<T>>, PluralInstanceType<T>>)
+  ) => Awaitable<SELECT<InstanceType<T>>, InstanceType<T>>)
   // currently no auto completion of columns, due to complexity
 
 export interface INSERT<T> extends Columns<T>, InUpsert<T> {}

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -1,18 +1,13 @@
-import { ArrayConstructable } from '../../../../apis/internal/inference'
-import { QLExtensions_ } from '../../../../apis/internal/query'
-import { DeepRequired } from '../../../../apis/internal/util'
 import { QLExtensions } from '../../../../apis/ql'
 import { Foo, Foos, attach } from './dummy'
 
 // unwrapped plural types
 let sel: SELECT<Foos>
 sel = SELECT(Foo)
-sel = SELECT(Foo, 42)
 sel = SELECT(Foo.drafts)
 sel = SELECT(Foos.drafts)
 sel = SELECT.from(Foo.drafts)
 sel = SELECT.from(Foos.drafts)
-sel = SELECT.from(Foos.drafts, 42)
 
 let selSingular: SELECT<Foo> = undefined as unknown as SELECT<Foo>
 selSingular.columns('ref')  // auto suggested
@@ -104,6 +99,30 @@ DELETE([Foo, Foos])
 
 let selectOne: Foo
 let selectMany: Foos
+
+// SINGULAR TESTS
+selectOne = await SELECT.from(Foos.drafts, 42) // .drafts of plural still singular
+selectOne = await SELECT.from(Foo.drafts, 42)
+selectOne = await SELECT(Foo, 42)
+// explicitly select one
+selectOne = await SELECT.one.from(Foo)
+selectOne = await SELECT.one.from(Foo, 42)
+selectOne = await SELECT.one.from(Foo, 42)
+selectOne = await SELECT.one.from(Foo, 42, f => f.x)
+selectOne = await SELECT.one.from(Foo, f => f.x)
+selectOne = await SELECT.one.from(Foo).alias('Bars')
+// implicitly select one by specifying a key
+selectOne = await SELECT.from(Foo, 42)
+selectOne = await SELECT.from(Foo, 42, ["x"])
+selectOne = await SELECT.from(Foo, 42, (f: Foo) => f.x)
+
+selectMany = await SELECT.from(Foo)
+selectMany = await SELECT.from(Foo, (f: Foo) => f.x)
+selectMany = await SELECT.from(Foo).alias('Bars')
+await SELECT.from(Foo, f => attach(f.ref)('*'))
+
+// PLURAL TESTS
+selectOne = await SELECT(Foos, 42)
 // explicitly select one
 selectOne = await SELECT.one.from(Foos)
 selectOne = await SELECT.one.from(Foos, 42)
@@ -111,6 +130,7 @@ selectOne = await SELECT.one.from(Foos, 42, f => f.x)
 selectOne = await SELECT.one.from(Foos, f => f.x)
 selectOne = await SELECT.one.from(Foos).alias('Bars')
 // implicitly select one by specifying a key
+selectOne = await SELECT.from(Foos, 42)
 selectOne = await SELECT.from(Foos, 42)
 selectOne = await SELECT.from(Foos, 42, (f: Foo) => f.x)
 


### PR DESCRIPTION
This PR addresses the following issues

#### Sample schema
```cds
// model.cds
entity Books {
  key ID    : Integer;
      title : String;
}
```
#### Generated classes from cds-typer
```ts
class Book { }
class Books extends Array<Book> {}
```

#### Issues

~1) No compiler issues, but both queries  actually return type `any` instead of `Book`~
```ts
let selectOne: Book

selectOne = await SELECT.from(Books, 42)
selectOne = await SELECT.from(Books, 42, (b: Book) => b.title)
```

2) Produces typescript issues because the plural type is the assumed result of the queries
```ts
let selectOne: Book

selectOne = await SELECT.from(Book, 42)
selectOne = await SELECT.from(Book, 42, ["title"])
selectOne = await SELECT.from(Book, 42, (b: Book) => f.x)
```