### PR TITLE
feat: adds 'localized' variants to SELECT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - `cds.utils.colors` types
 - The CQL methods `.where` and `.having` now suggest property names for certain overloads.
 - `Service.before/on/after(event, target...)` now accept also an array of typer-generated classes in the `target` parameter
+- `localized` variants to `SELECT`
 
 ### Changed
 - Most `cds.requires` entries are now optionals.

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -79,11 +79,13 @@ export interface SELECT<T> extends Where<T>, And, Having<T>, GroupBy, OrderBy<T>
 }
 export class SELECT<T> extends ConstructedQuery<T> {
 
-  static one: SELECT_one & { from: SELECT_one }
-
+  static one: SELECT_one & { from: SELECT_one } & { localized: SELECT_one }
+  
   static distinct: typeof SELECT<StaticAny>
+  
+  static from: SELECT_from & { localized: SELECT_from }
 
-  static from: SELECT_from
+  static localized: SELECT_from & { from: SELECT_from }
 
   from: SELECT_from
     & TaggedTemplateQueryPart<this>

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -119,6 +119,25 @@ selectMany = await SELECT.from(Foos, (f: Foo) => f.x)
 selectMany = await SELECT.from(Foos).alias('Bars')
 await SELECT.from(Foos, f => attach(f.ref)('*'))
 
+// Localized queries
+// explicitly select one
+selectOne = await SELECT.one.localized(Foos)
+selectOne = await SELECT.one.localized(Foos, 42)
+
+// implicitly select one by specifying a key
+selectOne = await SELECT.from.localized(Foos, 42)
+selectOne = await SELECT.from.localized(Foos, 42, (f) => f.x)
+selectOne = await SELECT.localized.from(Foos, 42)
+selectOne = await SELECT.localized.from(Foos, 42, (f) => f.x)
+selectOne = await SELECT.localized(Foos, 42)
+selectOne = await SELECT.localized(Foos, 42, (f) => f.x)
+
+selectMany = await SELECT.from.localized(Foos)
+selectMany = await SELECT.from.localized(Foos).columns('x')
+selectMany = await SELECT.localized.from(Foos)
+selectMany = await SELECT.localized(Foos)
+selectMany = await SELECT.localized(Foos).columns('x')
+
 // projections (with Plural type, which should make the parameter a Singular)
 SELECT.from(Foos, f => {
     const iterator: QLExtensions<Foo> = f


### PR DESCRIPTION
Adds all possible variants with `localized` to `SELECT`

```ts
SELECT.one.localized(Foos)
SELECT.from.localized(Foos)
SELECT.localized(Foos));
SELECT.localized.from(Foos));
```

Extract from `@sap/cds/lib/ql/SELECT.js`

```js
...
return $((..._)       => new this()._select_or_from(..._), {
  localized: $((...x) => new this({localized:true})._select_or_from(...x),{
    columns: (..._)   => new this({localized:true}).columns(..._),
    from: (..._)      => new this({localized:true}).from(..._),
  }),
  one: $((...x)       => new this({one:true})._select_or_from(...x),{
    localized: (..._) => new this({one:true,localized:true}).from(..._)
  }),
  from: $((..._)      => new this().from(..._), {
    localized: (..._) => new this({localized:true}).from(..._)
  }),
})
...
```

Closes #257 