### PR TITLE
Fix cds ref where

### DIFF
--- a/apis/cqn.d.ts
+++ b/apis/cqn.d.ts
@@ -83,7 +83,7 @@ export type expr = ref | val | xpr | function_call | SELECT
 type ref = { ref: _segment[] }
 
 /** @private */
-type _segment = name & {
+type _segment = name | {
   id?: string,
   where?: _xpr,
   args?: _named,

--- a/apis/cqn.d.ts
+++ b/apis/cqn.d.ts
@@ -80,7 +80,7 @@ type ordering_term = expr & { sort?: 'asc' | 'desc', nulls?: 'first' | 'last' }
 export type expr = ref | val | xpr | function_call | SELECT
 
 /** @private */
-type ref = { ref: (name & { id?: string, where?: expr, args?: expr[] })[] }
+type ref = { ref: (name & { id?: string, where?: _xpr, args?: expr[] })[] }
 
 /** @private */
 type val = { val: any }

--- a/apis/cqn.d.ts
+++ b/apis/cqn.d.ts
@@ -80,7 +80,21 @@ type ordering_term = expr & { sort?: 'asc' | 'desc', nulls?: 'first' | 'last' }
 export type expr = ref | val | xpr | function_call | SELECT
 
 /** @private */
-type ref = { ref: (name & { id?: string, where?: _xpr, args?: expr[] })[] }
+type ref = { ref: _segment[] }
+
+/** @private */
+type _segment = name & {
+  id?: string,
+  where?: _xpr,
+  args?: _named,
+  groupBy: expr[],
+  having: _xpr,
+  orderBy: ordering_term[],
+  limit: { rows: expr, offset: expr },
+}
+
+/** @private */
+type _named = { [key: name]: expr }
 
 /** @private */
 type val = { val: any }


### PR DESCRIPTION
Fix cds.ref type to conform to https://cap.cloud.sap/docs/cds/cxn#references

This allows refs such as
```ts
const TravelRef = { ref:[{
  id:'TravelService.Travel',
  where:[ {ref:['TravelUUID']},'=',{val:'52657221A8E4645C17002DF03754AB66'} ]
}]} as cds.ref
```