### PR TITLE
Make constructors of query classes private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Added missing type for `cds.context.model`
 - Added missing type for `cds.context.model`
 - Added missing type for `req.query.elements`
+- Made constructors for query parts (`SELECT`, `UPDATE`, `DELETE`, ...) private, as they should only be accessed statically
 
 ### Added
 - `cds.app` typed as express.js application

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -78,6 +78,7 @@ export interface SELECT<T> extends Where<T>, And, Having<T>, GroupBy, OrderBy<T>
   columns: Columns<T, SELECT<T>>['columns'] & ((projection: Projection<T>) => this)
 }
 export class SELECT<T> extends ConstructedQuery<T> {
+  private constructor();
 
   static one: SELECT_one & { from: SELECT_one }
 
@@ -178,6 +179,7 @@ type SELECT_from =
 
 export interface INSERT<T> extends Columns<T>, InUpsert<T> {}
 export class INSERT<T> extends ConstructedQuery<T> {
+  private constructor();
 
   static into: (<T extends ArrayConstructable> (entity: T, entries?: Entries) => INSERT<SingularInstanceType<T>>)
     & (TaggedTemplateQueryPart<INSERT<unknown>>)
@@ -197,6 +199,7 @@ type Entries<T = any> = {[key:string]: T} | {[key:string]: T}
 
 export interface UPSERT<T> extends Columns<T>, InUpsert<T> {}
 export class UPSERT<T> extends ConstructedQuery<T> {
+  private constructor();
 
   static into: (<T extends ArrayConstructable> (entity: T, entries?: Entries) => UPSERT<SingularInstanceType<T>>)
     & (TaggedTemplateQueryPart<UPSERT<StaticAny>>)
@@ -212,6 +215,7 @@ export class UPSERT<T> extends ConstructedQuery<T> {
 
 export interface DELETE<T> extends Where<T>, And, ByKey {}
 export class DELETE<T> extends ConstructedQuery<T> {
+  private constructor();
 
   static from:
     TaggedTemplateQueryPart<Awaitable<SELECT<unknown>, InstanceType<StaticAny>>>
@@ -223,9 +227,8 @@ export class DELETE<T> extends ConstructedQuery<T> {
 }
 
 export interface UPDATE<T> extends Where<T>, And, ByKey {}
-
-
 export class UPDATE<T> extends ConstructedQuery<T> {
+  private constructor();
 
   // cds-typer plural
   // FIXME: this returned UPDATE<SingularInstanceType<T>> before. should UPDATE<Books>.entity(...) return Book or Books?
@@ -251,6 +254,7 @@ export class UPDATE<T> extends ConstructedQuery<T> {
 }
 
 export class CREATE<T> extends ConstructedQuery<T> {
+  private constructor();
 
   static entity (entity: EntityDescription): CREATE<EntityDescription>
 
@@ -259,7 +263,8 @@ export class CREATE<T> extends ConstructedQuery<T> {
 }
 
 export class DROP<T> extends ConstructedQuery<T> {
-
+  private constructor();
+  
   static entity (entity: EntityDescription): DROP<EntityDescription>
 
   DROP: CQN.DROP['DROP']

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -13,6 +13,8 @@ new UPSERT;
 new DELETE;
 // @ts-expect-error
 new CREATE; 
+// @ts-expect-error
+new DROP;
 
 // unwrapped plural types
 let sel: SELECT<Foos>

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -1,8 +1,18 @@
-import { ArrayConstructable } from '../../../../apis/internal/inference'
-import { QLExtensions_ } from '../../../../apis/internal/query'
-import { DeepRequired } from '../../../../apis/internal/util'
 import { QLExtensions } from '../../../../apis/ql'
 import { Foo, Foos, attach } from './dummy'
+
+// @ts-expect-error - only supposed to be used statically, constructors private
+new SELECT;
+// @ts-expect-error
+new INSERT;
+// @ts-expect-error
+new UPDATE;
+// @ts-expect-error
+new UPSERT;
+// @ts-expect-error
+new DELETE;
+// @ts-expect-error
+new CREATE; 
 
 // unwrapped plural types
 let sel: SELECT<Foos>


### PR DESCRIPTION
Disallow
```ts
new SELECT(...)
```
etc. by making all query constructors private, as they should only be used statically:
```ts
SELECT(...)
```