### PR TITLE
Add post-setup script as dependency lifecycle script as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "lint:fix": "npx eslint . --fix",
     "setup": "npm i && npm i file:. --no-save --force",
     "prerelease:ci-fix": "node .github/prerelease-fix.js",
-    "postinstall": "node ./scripts/postinstall.js"
+    "postinstall": "node ./scripts/postinstall.js",
+    "dependencies": "node ./scripts/postinstall.js"
   },
   "peerDependencies": {
     "@sap/cds": "^8.0.0"


### PR DESCRIPTION
Run post-setup script to create symlink on [`dependencies`](https://docs.npmjs.com/cli/v9/using-npm/scripts#dependencies) life cycle event as well, in addition to the current `postinstall` one. This should catch additional use cases where `node_modules` is manipulated in any way without having triggered a full installation.

As the symlinking script is idempotent, this should not cause any issues with the existing `postinstall` script.