### PR TITLE
fix: adds correct type inference when using `.columns` in SELECT

### DIFF
--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -75,7 +75,7 @@ export declare class QL<T> {
 
 export interface SELECT<T> extends Where<T>, And, Having<T>, GroupBy, OrderBy<T>, Limit {
   // overload specific to SELECT
-  columns: Columns<T, SELECT<T>>['columns'] & ((projection: Projection<T>) => this)
+  columns: Columns<T, this>['columns'] & ((projection: Projection<T>) => this)
 }
 export class SELECT<T> extends ConstructedQuery<T> {
   private constructor();

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -208,12 +208,36 @@ SELECT.from(Foos).columns(f => {
     const number: QLExtensions<number> = f.x
 })
 
-SELECT.from(Foos).columns(['entityIDColumn', 'parentIDColumn'])
-SELECT.from(Foos).columns('entityIDColumn', 'parentIDColumn')
-SELECT.from(Foos).columns([{ ref: ['entityIDColumn'] }])
-SELECT.from(Foos).columns({ ref: ['entityIDColumn'] })
+// @ts-expect-error invalid key of result line
+SELECT.from(Foos).columns(['entityIDColumn', 'parentIDColumn']).then(r => r[0].some)
+SELECT.from(Foos).columns(['entityIDColumn', 'parentIDColumn']).then(r => r[0].ref)
+// @ts-expect-error invalid key of result line
+SELECT.from(Foos).columns('entityIDColumn', 'parentIDColumn').then(r => r[0].some)
+SELECT.from(Foos).columns('entityIDColumn', 'parentIDColumn').then(r => r[0].ref)
+// @ts-expect-error invalid key of result line
+SELECT.from(Foos).columns([{ ref: ['entityIDColumn'] }]).then(r => r[0].some)
+SELECT.from(Foos).columns([{ ref: ['entityIDColumn'] }]).then(r => r[0].ref)
+// @ts-expect-error invalid key of result line
+SELECT.from(Foos).columns({ ref: ['entityIDColumn'] }).then(r => r[0].some)
+SELECT.from(Foos).columns({ ref: ['entityIDColumn'] }).then(r => r[0].ref)
+
 SELECT.from `Books` .columns ( 'title', {ref:['author','name'],as:'author'} )
 SELECT.from `Books` .columns (['title', {ref:['author','name'],as:'author'} ])
+
+// @ts-expect-error invalid key of result
+SELECT.one.from(Foos).columns(['entityIDColumn', 'parentIDColumn']).then(r => r.some)
+SELECT.one.from(Foos).columns(['entityIDColumn', 'parentIDColumn']).then(r => r.ref)
+// @ts-expect-error invalid key of result
+SELECT.one.from(Foos).columns('entityIDColumn', 'parentIDColumn').then(r => r.some)
+SELECT.one.from(Foos).columns('entityIDColumn', 'parentIDColumn').then(r => r.ref)
+// @ts-expect-error invalid key of result
+SELECT.one.from(Foos).columns([{ ref: ['entityIDColumn'] }]).then(r => r.some)
+SELECT.one.from(Foos).columns([{ ref: ['entityIDColumn'] }]).then(r => r.ref)
+// @ts-expect-error invalid key of result
+SELECT.one.from(Foos).columns({ ref: ['entityIDColumn'] }).then(r => r.some)
+SELECT.one.from(Foos).columns({ ref: ['entityIDColumn'] }).then(r => r.ref)
+
+INSERT.into(Foos).values([1,2,3])
 
 // tagged template strings
 // literal


### PR DESCRIPTION
The rework in `ql.d.ts` resulted in missing/incorrect type inference when using `.columns` in `SELECT` queries.

![image](https://github.com/user-attachments/assets/15f9cfb0-9ce9-4ec4-8284-0878e6173e17)

As a result the result of such a query is no longer typed as expected but has an `any` type instead

Closes #322 