### PR TITLE
Add missing types for Event.on/ Event.before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.8.0 - tbd
 
+### Fixed
+- Added missing type for `Request.before('commit', …)`
+- Added missing types for `Request.on('succeeded' | 'failed' | 'done', …)`
+
 ## Version 0.7.0 - 24-10-24
 
 ### Fixed
-- Added missing type for `cds.context.model`
 - Added missing type for `cds.context.model`
 - Added missing type for `req.query.elements`
 - Made constructors for query parts (`SELECT`, `UPDATE`, `DELETE`, ...) private, as they should only be accessed statically

--- a/apis/events.d.ts
+++ b/apis/events.d.ts
@@ -40,6 +40,10 @@ export class Event extends EventContext {
 
   headers: any
 
+  before(phase: 'commit', handler: () => void)
+
+  on(phase: 'succeeded' | 'failed' | 'done', handler: () => void)
+
 }
 
 /**

--- a/test/typescript/apis/project/cds-services.ts
+++ b/test/typescript/apis/project/cds-services.ts
@@ -286,6 +286,18 @@ srv.before('DELETE', [Foos, Bars], req => isOneOfMany(req))
 srv.after('DELETE', [Foo, Bar], (data) => { isOneOfMany(data); return data })
 srv.after('DELETE', [Foos, Bars], (data) => isOneOfMany(data))
 
+srv.on('READ', Foo, req => {
+  req.before('commit', ()=>{})
+  // @ts-expect-error
+  req.before('anything else', ()=>{})
+  req.on('done', ()=>{})
+  req.on('failed', ()=>{})
+  req.on('succeeded', ()=>{})
+  // @ts-expect-error
+  req.on('anything else', ()=>{})
+})
+
+
 // unbound
 srv.before(action, (req) => {
   req.data.foo


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-types/issues/38

https://cap.cloud.sap/docs/node.js/events#eve-before-commit