### PR TITLE
Move compile.d.ts into models.d.ts to follow CAPire

### DIFF
--- a/apis/compile.d.ts
+++ b/apis/compile.d.ts
@@ -1,7 +1,0 @@
-import { CSN } from './csn'
-
-/**
- * Minifies a given CSN model by removing all unused1 types and aspects, as well all entities tagged with `@cds.persistence.skip:'if-unused'`
- * @see [capire](https://cap.cloud.sap/docs/node.js/cds-compile#cds-minify)
- */
-export function minify (model: CSN): CSN

--- a/apis/facade.d.ts
+++ b/apis/facade.d.ts
@@ -7,7 +7,6 @@ export * from './events'
 export * from './utils'
 export * from './cqn'
 export * from './global'
-export * from './compile'
 export { log, debug } from './log'
 export { test } from './test'
 

--- a/apis/models.d.ts
+++ b/apis/models.d.ts
@@ -196,6 +196,12 @@ export namespace linked {
 }
 
 /**
+ * Minifies a given CSN model by removing all unused1 types and aspects, as well all entities tagged with `@cds.persistence.skip:'if-unused'`
+ * @see [capire](https://cap.cloud.sap/docs/node.js/cds-compile#cds-minify)
+ */
+export function minify (model: csn.CSN): csn.CSN
+
+/**
  * Turns the given plain CSN model into a reflected model
  * @see [capire](https://cap.cloud.sap/docs/node.js/cds-reflect)
  */

--- a/test/typescript/apis/project/cds-models.ts
+++ b/test/typescript/apis/project/cds-models.ts
@@ -1,0 +1,4 @@
+import * as cds from '@sap/cds'
+
+let model = undefined as unknown as cds.csn.CSN
+model = cds.minify(model)


### PR DESCRIPTION
`cds.minify` was incorrectly put in its own _compile.d.ts_, but should be in _models.d.ts_, as can be seen in [CAPire](https://cap.cloud.sap/docs/node.js/cds-compile#cds-minify).