### PR TITLE
fix: use `Required` instead of `DeepRequired` in projection function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.9.0 - tbd
 
+### Fixed
+
+- Use `Required` instead of `DeepRequired` in projection function to avoid complexity errors from TypeScript
+
 ## Version 0.8.0 - 24-11-26
 
 ### Fixed

--- a/apis/internal/query.d.ts
+++ b/apis/internal/query.d.ts
@@ -3,7 +3,7 @@ import type { entity } from '../linked/classes'
 import type { column_expr, ref } from '../cqn'
 import type { ArrayConstructable, Constructable, SingularInstanceType, Unwrap, UnwrappedInstanceType } from './inference'
 import { ConstructedQuery } from '../ql'
-import { KVPairs, DeepRequired } from './util'
+import { KVPairs } from './util'
 
 // https://cap.cloud.sap/docs/node.js/cds-ql?q=projection#projection-functions
 type Projection<T> = (e: QLExtensions<T extends ArrayConstructable ? SingularInstanceType<T> : T>) => void
@@ -168,7 +168,7 @@ export interface InUpsert<T> {
 }
 
 // don't wrap QLExtensions in more QLExtensions (indirection to work around recursive definition)
-export type QLExtensions<T> = T extends QLExtensions_<any> ? T : QLExtensions_<DeepRequired<T>>
+export type QLExtensions<T> = T extends QLExtensions_<any> ? T : QLExtensions_<Required<T>>
 
 /**
  * QLExtensions are properties that are attached to entities in CQL contexts.

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -213,6 +213,11 @@ SELECT.from(Foos).columns(f => {
     const number: QLExtensions<number> = f.x
 })
 
+// deep projection nesting
+SELECT.from(Foos, f => f.ref(r => r.ref(r => r.ref(r => {
+    const x: number = r.x
+}))))
+
 // @ts-expect-error invalid key of result line
 SELECT.from(Foos).columns(['entityIDColumn', 'parentIDColumn']).then(r => r[0].some)
 SELECT.from(Foos).columns(['entityIDColumn', 'parentIDColumn']).then(r => r[0].ref)


### PR DESCRIPTION
Closes #348 