### PR TITLE
fix: add missing type inference to `.set`/`.with` of `UPDATE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.9.0 - tbd
 
+### Fixed
+- Added missing type inference for `.set`/`.with` of `UPDATE`
+
 ## Version 0.8.0 - 24-11-26
 
 ### Fixed

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -240,14 +240,11 @@ export class UPDATE<T> extends ConstructedQuery<T> {
 
   // cds-typer plural
   static entity: (TaggedTemplateQueryPart<UPDATE<StaticAny>>)
-   // FIXME: this returned UPDATE<SingularInstanceType<T>> before. should UPDATE<Books>.entity(...) return Book or Books?
+    // UPDATE<SingularInstanceType<T>> is used here so type inference in set/with has the property keys of the singular type
     & (<T extends ArrayConstructable> (entity: T, primaryKey?: PK) => UPDATE<SingularInstanceType<T>>)
     & (<T extends Constructable> (entity: T, primaryKey?: PK) => UPDATE<InstanceType<T>>)
     & ((entity: EntityDescription, primaryKey?: PK) => UPDATE<StaticAny>)
     & (<T> (entity: T, primaryKey?: PK) => UPDATE<T>)
-
-  // with (block: (e:T)=>void) : this
-  // set (block: (e:T)=>void) : this
 
   // simple value   > title: 'Some Title'
   // qbe expression > stock: { '-=': quantity }  
@@ -255,8 +252,7 @@ export class UPDATE<T> extends ConstructedQuery<T> {
   set: TaggedTemplateQueryPart<this>
     & ((data: {[P in keyof T]?: T[P] | {[op in QbeOp]?: any} | CQN.xpr}) => this)
     
-  with: TaggedTemplateQueryPart<this>
-    & ((data: {[P in keyof T]?: T[P] | {[op in QbeOp]?: any} | CQN.xpr}) => this)
+  with: typeof this.set
 
   UPDATE: CQN.UPDATE['UPDATE']
 

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -238,7 +238,6 @@ export interface UPDATE<T> extends Where<T>, And, ByKey {}
 export class UPDATE<T> extends ConstructedQuery<T> {
   private constructor();
 
-  // cds-typer plural
   static entity: (TaggedTemplateQueryPart<UPDATE<StaticAny>>)
     // UPDATE<SingularInstanceType<T>> is used here so type inference in set/with has the property keys of the singular type
     & (<T extends ArrayConstructable> (entity: T, primaryKey?: PK) => UPDATE<SingularInstanceType<T>>)
@@ -246,17 +245,22 @@ export class UPDATE<T> extends ConstructedQuery<T> {
     & ((entity: EntityDescription, primaryKey?: PK) => UPDATE<StaticAny>)
     & (<T> (entity: T, primaryKey?: PK) => UPDATE<T>)
 
-  // simple value   > title: 'Some Title'
-  // qbe expression > stock: { '-=': quantity }  
-  // cqn expression > descr: {xpr: [{ref:[descr]}, '||', 'Some addition to descr.']}
-  set: TaggedTemplateQueryPart<this>
-    & ((data: {[P in keyof T]?: T[P] | {[op in QbeOp]?: any} | CQN.xpr}) => this)
-    
-  with: typeof this.set
-
+  set: UpdateSet<this, T>
+  with: UpdateSet<this, T>
+  
   UPDATE: CQN.UPDATE['UPDATE']
 
 }
+
+/**
+ * Represents updatable block that can be passed to either `.set` or `.with`
+ * of an `UPDATE` query
+ */
+type UpdateSet<This, T> = TaggedTemplateQueryPart<This>
+  // simple value   > title: 'Some Title'
+  // qbe expression > stock: { '-=': quantity }  
+  // cqn expression > descr: {xpr: [{ref:[descr]}, '||', 'Some addition to descr.']}
+  & ((data: {[P in keyof T]?: T[P] | {[op in QbeOp]?: T[P]} | CQN.xpr}) => This)
 
 export class CREATE<T> extends ConstructedQuery<T> {
   private constructor();

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -1,4 +1,5 @@
 import { QLExtensions } from '../../../../apis/ql'
+import { linked } from '../../../../apis/models';
 import { Foo, Foos, attach } from './dummy'
 
 // @ts-expect-error - only supposed to be used statically, constructors private
@@ -94,11 +95,11 @@ ins.columns("x") // x was suggested by code completion
 ins.INSERT.into === "foo"
 INSERT.into("Bla").as(SELECT.from("Foo"))
 
-let upd: UPDATE<Foos>
+let upd: UPDATE<Foo>
 upd = UPDATE(Foo, 42)
-upd.set({})
+upd.set({x:4})
 upd = UPDATE.entity(Foos)
-upd.set({})
+upd.set({x:1})
 upd.UPDATE.entity === "foo"
 
 let ups:UPSERT<Foo>
@@ -278,3 +279,30 @@ INSERT.into('Foos').rows([[1,2,3]])
 INSERT.into('Foos').rows([[1,2,3],[1,2]])
 // @ts-expect-error
 INSERT.into('Foos').values([[1,2,3]])
+
+// UPDATE: checks with typed classes
+UPDATE(Foo, 42).set({ x: 4}).where({ x: 44 })
+UPDATE(Foos, 42).set({ x: 4}).where({ x: 44 })
+// @ts-expect-error - invalid property of Foo
+UPDATE(Foos, 4).set({ aa: 4 });
+// @ts-expect-error - invalid property type of Foo.x
+UPDATE(Foo).where({ x: 4 }).set({ x: 'asdf', ref: { x: 4 }})
+UPDATE(Foos).where({ x: 4 }).set({ x: 4, ref: { x: 4 }})
+UPDATE.entity(Foos).set({ x: 4});
+
+UPDATE.entity(Foos).set({
+  x: {'+=': 4 },
+  ref: { x: 5 },
+  y: { xpr: [{ ref: ["asdf"] }, "||", "asdf"] }
+});
+
+// @ts-expect-error - invalid operator of qbe expression
+UPDATE(Foo).with({x: {'--': 4}})
+
+// @ts-expect-error - invalid property name of xpr
+UPDATE(Foos).with({x: {xpr: [{funcs: ""}]}})
+
+// untyped, no syntax errors
+UPDATE.entity("Foos").set({ test: {xp: "4"} });
+UPDATE.entity({} as linked.classes.entity).set({ asdf: 434 });
+UPDATE`Foos`.set`x = 4`.where`x > 10`

--- a/test/typescript/apis/project/dummy.ts
+++ b/test/typescript/apis/project/dummy.ts
@@ -6,6 +6,7 @@
 export class Foo {
     static readonly drafts: typeof Foo
     x: number = 42
+    y?: string
     ref?: Foo
     refs?: Foo[]
   }


### PR DESCRIPTION
Adds proper type inference for `.set`/`.with` of `UPDATE` queries when using cds-typer classes.

All variants are now supported as documented [here](https://cap.cloud.sap/docs/node.js/cds-ql#set)

```js
let [ ID, quantity ] = [ 201, 1 ]
UPDATE (Books,ID) .with ({
  title: 'Sturmhöhe',       //>  simple value
  stock: {'-=': quantity},    //>  qbe expression
  descr: {xpr: [{ref:[descr]}, '||', 'Some addition to descr.']}
})
```

![image](https://github.com/user-attachments/assets/9017a055-1ff3-49e9-b051-039e65675df8)
![image](https://github.com/user-attachments/assets/f8ecae94-b900-4c5d-a42f-4f90d84a6b93)
![image](https://github.com/user-attachments/assets/41c37335-a295-4571-bf55-371190d4948c)

### Shortcomings

When using the following variants

```ts
UPDATE.entity("Foos").set({ test: {xp: "4"} });
UPDATE.entity({} as linked.classes.entity).set({ asdf: 434 });
UPDATE`Foos`.set`x = 4`.where`x > 10`
```

there is no intellisense at all, so it _works_ as before. It would be great to also get intellisense working for _qbe_ and _cqn_ expressions for those, but I didn't manage.