### PR TITLE
feat: adds `log` to `cds.env`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.9.0 - tbd
+- Adds missing properties for `log` in `cds.env`
 
 ## Version 0.8.0 - 24-11-26
 

--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -16,7 +16,7 @@ export const env: {
   profiles: string[],
   log: {
     user: boolean,
-    levels: Record<string, 'info' | 'warn' | 'error' | 'debug' | 'trace'>,
+    levels: Record<string, 'silent' | 'info' | 'warn' | 'error' | 'debug' | 'trace' | 'silly' | 'verbose'>,
     als_custom_fields: Record<string, number>,
     cls_custom_fields: string[],
   },

--- a/apis/env.d.ts
+++ b/apis/env.d.ts
@@ -14,6 +14,12 @@ export const env: {
     [key: string]: any,
   },
   profiles: string[],
+  log: {
+    user: boolean,
+    levels: Record<string, 'info' | 'warn' | 'error' | 'debug' | 'trace'>,
+    als_custom_fields: Record<string, number>,
+    cls_custom_fields: string[],
+  },
   requires: env.Requires,
   folders: {
     app: string,

--- a/test/typescript/apis/project/cds-env.ts
+++ b/test/typescript/apis/project/cds-env.ts
@@ -9,6 +9,11 @@ env.folders.foo = ''
 env.build = ''
 env.hana = ''
 
+env.log.levels['cli'] === 'debug'
+env.log.cls_custom_fields.length
+env.log.als_custom_fields['query'] === 0
+Object.keys(env.log.als_custom_fields)
+
 env.requires.auth.kind = ''
 env.requires.auth.credentials!.url = ''
 env.requires.auth.credentials!.clientid = ''


### PR DESCRIPTION
Add missing `log` property to `cds.env`.

- General configuration <https://cap.cloud.sap/docs/node.js/cds-log#configuration>
- Log levels: <https://cap.cloud.sap/docs/node.js/cds-log#configuring-log-levels>
- Custom properties <https://cap.cloud.sap/docs/node.js/cds-log#custom-fields>
