### PR TITLE
fix: allow untyped UPDATE for req.[subject|target]

### DIFF
--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -7,6 +7,7 @@ import {
   SingularInstanceType,
   PluralInstanceType
 } from './internal/inference'
+import { Definition } from './linked'
 import { ref } from './cqn'
 import {
   And,
@@ -244,7 +245,7 @@ export class UPDATE<T> extends ConstructedQuery<T> {
     // UPDATE<SingularInstanceType<T>> is used here so type inference in set/with has the property keys of the singular type
     & (<T extends ArrayConstructable> (entity: T, primaryKey?: PK) => UPDATE<SingularInstanceType<T>>)
     & (<T extends Constructable> (entity: T, primaryKey?: PK) => UPDATE<InstanceType<T>>)
-    & ((entity: EntityDescription, primaryKey?: PK) => UPDATE<StaticAny>)
+    & ((entity: EntityDescription | ref | Definition, primaryKey?: PK) => UPDATE<StaticAny>)
     & (<T> (entity: T, primaryKey?: PK) => UPDATE<T>)
 
   set: UpdateSet<this, T>

--- a/test/typescript/apis/project/cds-services.ts
+++ b/test/typescript/apis/project/cds-services.ts
@@ -191,6 +191,15 @@ srv.after('UPDATE', Books, (results, req) => {
   results[0]
 })
 
+srv.on("action1", req => {
+  UPDATE(req.subject).with({ x: "a" })
+  UPDATE(req.subject).with({ x: { "=": 4 } })
+  UPDATE(req.subject).with({ x: { xpr: [{ ref: ["asdf"] }, "||", "asdf"] } })
+  UPDATE(req.target).with({ x: 4 })
+  UPDATE(req.target).with({ x: { "=": 4 } })
+  UPDATE(req.target).with({ x: { xpr: [{ ref: ["asdf"] }, "||", "asdf"] } })
+})
+
 srv.on('CREATE', (req, next) => {
   req.data
   next()


### PR DESCRIPTION
Fixes #362 

P.S.: Changelog update can be skipped, as the initial change of UPDATE is already mentioned