### PR TITLE
Run dependabot only once per week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,12 @@ updates:
   directory: /
   versioning-strategy: increase-if-necessary
   schedule:
-    interval: daily
+    interval: weekly
+  groups:
+    production-dependencies:
+      dependency-type: "production"
+    development-dependencies:
+      dependency-type: "development"
   ignore:
     - dependency-name: "chai"
         # chai 5 doesn't work atm w/ cds.test


### PR DESCRIPTION
This will amount in less PRs (up to two per week, one per group) that are opened on Monday, instead of having a myriad of PRs over the week whenever a dependency updates.