### PR TITLE
feat: Add types for anonymous, privileged and default users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - Added missing properties for `log` in `cds.env`
 - Added overload for `service.read` to be called with a `ref`
+- Added types for anonymous, privileged, and default user
 
 ### Changed
 - removed dependency to `@types/express: ^4.17.21` in favour of a peerDependency to `@types/express: >=4`

--- a/apis/events.d.ts
+++ b/apis/events.d.ts
@@ -137,9 +137,28 @@ export class User {
 
   roles: Array<string> | Record<string, string>
 
+  static Anonymous: typeof Anonymous
+
+  static anonymous: Anonymous
+
   static Privileged: typeof Privileged
 
+  static privileged: Privileged
+
+  static default: User
+
   is (role: string): boolean
+
+}
+
+/**
+ * Subclass representing unauthenticated users.
+ */
+declare class Anonymous extends User {
+
+  constructor ()
+
+  is (): boolean
 
 }
 

--- a/test/typescript/apis/project/cds-user.ts
+++ b/test/typescript/apis/project/cds-user.ts
@@ -22,9 +22,24 @@ user.tenant
 user.locale
 
 user.is('someRole')
+
 const privileged = new cds.User.Privileged()
 privileged.is()
 privileged.id === 'privileged'
+const readyToUsePrivileged = cds.User.privileged
+readyToUsePrivileged.is()
+readyToUsePrivileged.id === 'privileged'
+
+const anonymous = new cds.User.Anonymous()
+anonymous.is()
+anonymous.id === 'anonymous'
+const readyToUseAnonymous = cds.User.anonymous
+readyToUseAnonymous.is()
+readyToUseAnonymous.id === 'anonymous'
+
+const readyToUseDefault = cds.User.default
+readyToUseDefault.id === 'anonymous' // since the default default is cds.User.anonymous
+
 new (class extends User {
   is(): boolean {
     return true


### PR DESCRIPTION
As discussed in https://github.com/cap-js/docs/pull/1483#issuecomment-2531015473, adding types for...
- https://cap.cloud.sap/docs/node.js/authentication#privileged-user
- https://cap.cloud.sap/docs/node.js/authentication#anonymous-user
- https://cap.cloud.sap/docs/node.js/authentication#default-user