### PR TITLE
Derive service functions through connect.to

### DIFF
--- a/apis/server.d.ts
+++ b/apis/server.d.ts
@@ -40,6 +40,8 @@ export const connect: {
 		 */
   to(options: cds_connect_options): Promise<Service>,
 
+  to<S>(datasource: S, options?: cds_connect_options): Promise<cds.CdsFunctions<S> & Service>,
+
   /**
 		 * Connects the primary datasource.
 		 * @see [capire](https://cap.cloud.sap/docs/node.js/cds-connect)

--- a/apis/server.d.ts
+++ b/apis/server.d.ts
@@ -15,23 +15,32 @@ export const connect: {
 
   /**
 		 * Connects to a specific datasource.
-		 * @example cds.connect.to ('service')
+		 * @example await cds.connect.to ('service')
 		 * @see [capire](https://cap.cloud.sap/docs/node.js/cds-connect#cds-connect-to)
 		 */
   to(datasource: string, options?: cds_connect_options): Promise<Service>,
 
   /**
 	 * Shortcut for 'db' as the primary database returning `cds.DatabaseService`
-	 * @example cds.connect.to ('db')
+	 * @example await cds.connect.to ('db')
 	*/
   to(datasource: 'db', options?: cds_connect_options): Promise<cds.DatabaseService>,
 
   /**
 	 * Connects to a specific datasource via a Service subclass
-	 * @example cds.connect.to (ServiceClass)
+	 * @example await cds.connect.to (ServiceClass)
 	 * @see [capire](https://cap.cloud.sap/docs/node.js/cds-connect#cds-connect-to)
 	 */
   to<S extends Service>(datasource: {new(): S}, options?: cds_connect_options): Promise<S>,
+
+  /**
+	 * Connects to a specific datasource via a Service class from cds-typer
+	 * @example
+	 *   import ServiceClass from '#cds-models/SomeService'
+	 *   await cds.connect.to (ServiceClass)
+	 * @see [capire](https://cap.cloud.sap/docs/node.js/cds-connect#cds-connect-to)
+	 */
+  to<S>(datasource: S, options?: cds_connect_options): Promise<cds.CdsFunctions<S> & Service>,
 
   /**
 		 * Connects to a specific datasource via options.
@@ -39,8 +48,6 @@ export const connect: {
 		 * @see [capire](https://cap.cloud.sap/docs/node.js/cds-connect#cds-connect-to)
 		 */
   to(options: cds_connect_options): Promise<Service>,
-
-  to<S>(datasource: S, options?: cds_connect_options): Promise<cds.CdsFunctions<S> & Service>,
 
   /**
 		 * Connects the primary datasource.

--- a/apis/services.d.ts
+++ b/apis/services.d.ts
@@ -356,6 +356,12 @@ type CdsFunction = {
   __returns: any,
 }
 
+// extracts all CdsFunction properties from T
+/**
+ * @beta helper
+ */
+type CdsFunctions<T> = Pick<T, { [K in keyof T]: T[K] extends CdsFunction ? K : never }[keyof T]>
+
 /**
  * Types herein can be used to type handler functions that are not declared in line:
  * @example


### PR DESCRIPTION
Enables https://github.com/cap-js/cds-typer/pull/454

See https://github.com/chgeo/issue-named-service-exports/issues/1

No changelog entry, as this enables additional internal logic.