### PR TITLE
Remove `cds.Float` from CSN types

### DIFF
--- a/apis/csn.d.ts
+++ b/apis/csn.d.ts
@@ -68,7 +68,7 @@ export interface service extends any_ { }
 export interface type extends any_ {
   type?: 'cds.Boolean' |
          'cds.UUID' | 'cds.String' | 'cds.LargeString' | 'cds.Binary' | 'cds.LargeBinary' | 'cds.Vector' |
-         'cds.Integer' | 'cds.UInt8' | 'cds.Int16' | 'cds.Int32' | 'cds.Int64' | 'cds.Float' | 'cds.Double' | 'cds.Decimal' |
+         'cds.Integer' | 'cds.UInt8' | 'cds.Int16' | 'cds.Int32' | 'cds.Int64' | 'cds.Double' | 'cds.Decimal' |
          'cds.Date' | 'cds.Time' | 'cds.DateTime' | 'cds.Timestamp' |
          'cds.Association' | 'cds.Composition' |
          FQN & Record<never,never> // allow any other CDS type as well (e.g. 'User')


### PR DESCRIPTION
This type is deprecated/removed and using it gives a compiler error such as this:
```
No artifact has been found with name “Float”CDS (compiler)(ref-undefined-art)
t0.cds(5, 22): entity:“cds.xt.Tenants”/element:“metadata”
```
