### PR TITLE
Fix link to Node.js documentation for `srv.emit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Added missing type inference for `.set`/`.with` of `UPDATE`
 - Added missing type inference for `.entries` of `UPSERT` and `INSERT`
 - Variants of `SELECT.one(T)` will now return `T | null`, instead of `T`
+- Documentation link to `srv.emit`
 
 ## Version 0.8.0 - 24-11-26
 

--- a/apis/server.d.ts
+++ b/apis/server.d.ts
@@ -79,7 +79,7 @@ export function on (event: 'connect', listener: (srv: Service) => void): _cds
 
 
 /**
-	 * Emitted at the very beginning of the bootsrapping process, when the
+	 * Emitted at the very beginning of the bootstrapping process, when the
 	 * express application has been constructed but no middlewares or routes
 	 * added yet.
 	 */
@@ -162,10 +162,10 @@ interface cds_connect_options {
   credentials?: object
 }
 
-type Middleswares = 'context' | 'trace' | 'auth' | 'ctx_model' | string
+type Middlewares = 'context' | 'trace' | 'auth' | 'ctx_model' | string
 
 export const middlewares: {
-  add: (middleware: RequestHandler, pos?: XOR<XOR<{ at: number }, { after: Middleswares }>, { before: Middleswares }>) => void,
+  add: (middleware: RequestHandler, pos?: XOR<XOR<{ at: number }, { after: Middlewares }>, { before: Middlewares }>) => void,
 }
 
 /**

--- a/apis/services.d.ts
+++ b/apis/services.d.ts
@@ -165,7 +165,7 @@ export class Service extends QueryAPI {
 
   /**
    * Constructs and emits an asynchronous event.
-   * @see [capire docs](https://cap.cloud.sap/docs/core-services#srv-emit-event)
+   * @see [capire docs](https://cap.cloud.sap/docs/node.js/core-services#srv-emit-event)
    */
   emit: {
     <T = any>(details: { event: types.event, data?: object, headers?: object }): Promise<T>,


### PR DESCRIPTION
Fixes a broken link to the `srv.emit` documentation and a few typos my spell checker complained about :)