### PR TITLE
ci: consume org workflows

### DIFF
--- a/.github/workflows/enforce-changelog.yml
+++ b/.github/workflows/enforce-changelog.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 jobs:
-  label_dependabot:
+  label-dependabot:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -31,6 +31,7 @@ jobs:
             }
   changelog:
     runs-on: ubuntu-latest
+    needs: label-dependabot
     steps:
     - uses: dangoslen/changelog-enforcer@v3
       with:

--- a/.github/workflows/enforce-changelog.yml
+++ b/.github/workflows/enforce-changelog.yml
@@ -1,0 +1,38 @@
+name: Enforce Changelog
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  label_dependabot:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check if PR is by Dependabot
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prAuthor = context.payload.pull_request.user.login;
+            const prNumber = context.payload.pull_request.number;
+            const repoOwner = context.repo.owner;
+            const repoName = context.repo.repo;
+
+            if (prAuthor === 'dependabot[bot]' || prAuthor === 'dependabot') {
+              core.info(`PR #${prNumber} is authored by Dependabot. Adding label...`);
+              await github.rest.issues.addLabels({
+                owner: repoOwner,
+                repo: repoName,
+                issue_number: prNumber,
+                labels: ['skip changelog']
+              });
+            } else {
+              core.info(`PR #${prNumber} is not authored by Dependabot. No action taken.`);
+            }
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dangoslen/changelog-enforcer@v3
+      with:
+        skipLabels: "skip changelog"
+        missingUpdateErrorMessage: "PR does not update CHANGELOG.md! If this was done on purpose, add the 'skip changelog' label."

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -40,6 +40,8 @@ jobs:
     - run: |
         npm i -g npm
         npm ci
+        npm run test:common
+        npm run rollup:off
 
     - name: Run integration test with non-admin user on windows
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -37,10 +37,12 @@ jobs:
       with:
         node-version: ${{ matrix.version }}
 
+    # running test:setup inside run-as-non-admin causes problems with creating OS links
+    # -> run it outside of run-as-non-admin
     - run: |
         npm i -g npm
         npm ci
-        npm run test:common
+        npm run test:setup
         npm run rollup:off
 
     - name: Run integration test with non-admin user on windows

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -32,6 +32,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.version }}
@@ -39,9 +40,6 @@ jobs:
     - run: |
         npm i -g npm
         npm ci
-        npm install file:. --no-save --force
-        npm run prerelease:ci-fix
-        npm run rollup:off
 
     - name: Run integration test with non-admin user on windows
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  cap-org-lint:
+  lint:
     uses: cap-js/.github/.github/workflows/lint.yml@main
     secrets: inherit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,14 +9,5 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-    - name: Run Linter
-      run: |
-        npm ci
-        npm run lint
+    uses: cap-js/.github/.github/workflows/lint.yml@main
+    secrets: inherit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Linting1
+name: Linting
 
 on:
   pull_request:
@@ -8,6 +8,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint2:
+  cap-org-lint:
     uses: cap-js/.github/.github/workflows/lint.yml@main
     secrets: inherit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Linting
+name: Linting1
 
 on:
   pull_request:
@@ -8,6 +8,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint:
+  lint2:
     uses: cap-js/.github/.github/workflows/lint.yml@main
     secrets: inherit

--- a/.github/workflows/prepare-next-version.yml
+++ b/.github/workflows/prepare-next-version.yml
@@ -1,0 +1,27 @@
+
+name: Prepare Next Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      increment:
+        description: Increment version
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  pull-requests: write
+
+
+jobs:
+  prepare-next-version:
+    uses: cap-js/.github/.github/workflows/prepare-next-version.yml@main
+    secrets: inherit
+    with:
+      increment: ${{ github.event.inputs.increment }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,6 @@ jobs:
     - name: Run Unit Tests
       run: |
         npm ci
-        npm install file:. --no-save --force
-        npm run prerelease:ci-fix
-        npm run rollup && npm run rollup:on
         npm run test
 
     - name: get-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,14 @@ on:
         required: false
         default: false
         type: boolean
+      tag:
+        description: The tag to use during publish, values are latest, next
+        required: false
+        default: latest
+        type: choice
+        options:
+          - latest
+          - next
 
 permissions:
   contents: write
@@ -25,3 +33,4 @@ jobs:
     secrets: inherit
     with:
       dry-run: ${{ github.event.inputs.dry-run || false }}
+      tag: ${{ github.event.inputs.tag || 'latest'}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,50 +4,24 @@
 name: Release
 
 on:
+  push:
+    branches: main
+
   workflow_dispatch:
     inputs:
-      npmtag:
-        description: 'tag to use on npmjs'
-        type: choice
-        options:
-          - latest
-          - next
-        default: 'latest'
-        required: true
+      dry-run:
+        description: Dry run
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
 
+
 jobs:
-
-  publish-npm:
-    runs-on: ubuntu-latest
-    environment: npm
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 20
-        registry-url: https://registry.npmjs.org/
-
-    - name: Run Unit Tests
-      run: |
-        npm ci
-        npm run test
-
-    - name: get-version
-      id: package-version
-      uses: martinbeentjes/npm-get-version-action@v1.2.3
-    - name: Parse changelog
-      id: parse-changelog
-      uses: schwma/parse-changelog-action@v1.0.0
-      with:
-        version: '${{ steps.package-version.outputs.current-version }}'
-    - name: Create a GitHub release
-      uses: ncipollo/release-action@v1
-      with:
-        tag: 'v${{ steps.package-version.outputs.current-version }}'
-        body: '${{ steps.parse-changelog.outputs.body }}'
-    - run: npm publish --tag ${{ github.event.inputs.npmtag }} --access public
-      env:
-        NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+  release:
+    uses: cap-js/.github/.github/workflows/release.yml@main
+    secrets: inherit
+    with:
+      dry-run: ${{ github.event.inputs.dry-run || false }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,5 +29,5 @@ jobs:
       run: |
         npm ci
         npm run test:setup
-        npm run test:rollup-on
         npm run test:rollup-off
+        npm run test:rollup-on

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,6 @@ jobs:
     - name: Run Unit Tests
       run: |
         npm ci
-        npm run test
+        npm run test:setup
+        npm run test:rollup-on
+        npm run test:rollup-off

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.version }}
@@ -27,10 +28,4 @@ jobs:
     - name: Run Unit Tests
       run: |
         npm ci
-        npm install file:. --no-save --force
-        npm run prerelease:ci-fix
-        npm run rollup:off
-        npm run test
-
-        npm run rollup && npm run rollup:on
         npm run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,16 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## Version 0.10.0 - tbd
+## [Unreleased]
 
-## Version 0.9.0 - 25-01-13
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+## [0.9.0] - 25-01-13
 ### Added
 - Added missing properties for `log` in `cds.env`
 - Added overload for `service.read` to be called with a `ref`
@@ -28,7 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Variants of `SELECT.one(T)` will now return `T | null`, instead of `T`
 - Documentation link to `srv.emit`
 
-## Version 0.8.0 - 24-11-26
+## [0.8.0] - 24-11-26
 
 ### Fixed
 - Added missing type for `Request.before('commit', …)`
@@ -39,7 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Calling `SELECT.one('...').from(Plural)` now properly returns a single instance
 
 
-## Version 0.7.0 - 24-10-24
+## [0.7.0] - 24-10-24
 
 ### Fixed
 - Added missing type for `cds.context.model`
@@ -61,14 +68,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `cds.connect.to` now also supports using a precompiled model.
 - Properties of entities are no longer optional in projections, eliminating the need to perform optional chaining on them when using nested projections
 
-## Version 0.6.5 - 2024-08-13
+## [0.6.5] - 2024-08-13
 ### Fixed
 - The `@types/sap__cds` link created by the `postinstall` script now also works in monorepo setups where the target `@cap-js/cds-types` might already be preinstalled (often hoisted some levels up).
 
 ### Removed
 - Removed array-like methods from model parts (`.map`, `.find`, etc.). To still use them, apply spreading to object in question first.
 
-## Version 0.6.4 - 2024-08-05
+## [0.6.4] - 2024-08-05
 ### Added
 - `Service.emit(...)` can now also be called with custom events
 - `Service.before(...)` and `Service.after(...)` now accept bound and unbound functions as parameter
@@ -81,40 +88,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Fixed
 - `EACH` event has appropriately been renamed `each` to reflect runtime behaviour
 
-## Version 0.6.3 - 2024-07-19
+## [0.6.3] - 2024-07-19
 ### Fixed
 - Installation no longer fails if symlink `@types/sap__cds` exists
 
-## Version 0.6.2 - 2024-07-18
+## [0.6.2] - 2024-07-18
 ### Fixed
 - Symlink `@types/sap__cds` correctly created in case of upgrading `@cap-js/cds-types`.
 
-## Version 0.6.1 - 2024-07-18
+## [0.6.1] - 2024-07-18
 ### Fixed
 - Scripts `postinstall` and `prerelease:ci-fix` now work correctly on windows.
 
 ### Changed
 - `postinstall` script now creates a relative symlink from `@types/sap__cds` to allow the project to be moved/ renamed.
 
-## Version 0.6.0 - 2024-07-05
+## [0.6.0] - 2024-07-05
 This is a prerelease version (`next`) as a preview for the upcoming release of cds 8.
 ### Changed
 - Wrapped all types into an augmented module declaration for `@sap/cds`.
 - Added a postinstall script to symlink `@cap-js/cds-types` to `@types/sap__cds` to benefit from the default type resolution mechanism employed by Definitely Typed.
 
-## Version 0.5.0 - 2024-06-20
+## [0.5.0] - 2024-06-20
 This is a prerelease version (`next`) as a preview for the upcoming release of cds 8.
 
 ### Fixed
 - Linked definitions are now available via `cds.linked`, especially `cds.linked.LinkedCSN` and `cds.linked.classes` with its relevant type definitions
 
-## Version 0.4.0 - 2024-05-23
+## [0.4.0] - 2024-05-23
 This is a prerelease version (`next`) as a preview for the upcoming release of cds 8.
 
 ### Fixed
 - Corrected `exist(…)` to `exists(…)`
 
-## Version 0.3.0-beta.1 - 2024-05-23
+## [0.3.0-beta.1] - 2024-05-23
 
 ### Added
 - Added signatures for `cds.outboxed` and `cds.unboxed`
@@ -135,7 +142,7 @@ This is a prerelease version (`next`) as a preview for the upcoming release of c
 - `cds.log` can now also be called with the names of log levels
 - Reintroduced missing `QueryAPI.tx` and add deprecation note for `QueryAPI.transaction`
 
-## Version 0.2.0 - 2024-01-17
+## [0.2.0] - 2024-01-17
 
 ### Added
 
@@ -155,7 +162,7 @@ This is a prerelease version (`next`) as a preview for the upcoming release of c
 - `SELECT.from` got its `ref` property back
 
 
-## Version 0.1.0 - 2023-12-13
+## [0.1.0] - 2023-12-13
 
 ### Changed
 
@@ -165,7 +172,7 @@ This is a prerelease version (`next`) as a preview for the upcoming release of c
 
 - TSDoc comments have a proper structure
 
-## Version 0.0.1 - 2023-12-06
+## [0.0.1] - 2023-12-06
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "npm run test:common && npm run test:rollup-off && npm run test:rollup-on",
     "test:rollup-on": "npm run rollup && npm run rollup:on && jest --silent",
     "test:rollup-off": "npm run rollup:off && jest --silent",
-    "test:integration": "npm run test:common && npm run rollup:off && jest --testMatch \"**/test/**/*.integrationtest.js\"",
+    "test:integration": "jest --testMatch \"**/test/**/*.integrationtest.js\"",
     "rollup": "rm -rf dist/ && mkdir -p etc/ && npx -y @microsoft/api-extractor run --local --verbose && .github/rollup-patch.js",
     "rollup:on": "npm pkg set typings=dist/cds-types.d.ts && [ -d 'apis' ] && mv -- apis -apis || true",
     "rollup:off": "npm pkg set typings=apis/cds.d.ts  && [ -d '-apis' ] && mv -- -apis apis || true",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "README.md"
   ],
   "scripts": {
-    "test:common": "npm install file:. --no-save --force && npm run prerelease:ci-fix",
-    "test": "npm run test:common && npm run test:rollup-off && npm run test:rollup-on",
+    "test:setup": "npm install file:. --no-save --force && npm run prerelease:ci-fix",
+    "test": "npm run test:setup && npm run test:rollup-on",
     "test:rollup-on": "npm run rollup && npm run rollup:on && jest --silent",
     "test:rollup-off": "npm run rollup:off && jest --silent",
     "test:integration": "jest --testMatch \"**/test/**/*.integrationtest.js\"",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "README.md"
   ],
   "scripts": {
-    "test": "jest --silent",
-    "test:integration": "jest --testMatch \"**/test/**/*.integrationtest.js\"",
-    "test:rollup": "npm run rollup; npm run rollup:on; npm run test; npm run rollup:off",
+    "test:common": "npm install file:. --no-save --force && npm run prerelease:ci-fix",
+    "test": "npm run test:common && npm run test:rollup-off && npm run test:rollup-on",
+    "test:rollup-on": "npm run rollup && npm run rollup:on && jest --silent",
+    "test:rollup-off": "npm run rollup:off && jest --silent",
+    "test:integration": "npm run test:common && npm run rollup:off && jest --testMatch \"**/test/**/*.integrationtest.js\"",
     "rollup": "rm -rf dist/ && mkdir -p etc/ && npx -y @microsoft/api-extractor run --local --verbose && .github/rollup-patch.js",
     "rollup:on": "npm pkg set typings=dist/cds-types.d.ts && [ -d 'apis' ] && mv -- apis -apis || true",
     "rollup:off": "npm pkg set typings=apis/cds.d.ts  && [ -d '-apis' ] && mv -- -apis apis || true",


### PR DESCRIPTION
## First Draft
Open issues
- [x] adapt changelog to unreleased format
- [x] use next version workflow
- [x] lint check renaming
- [x] test.yml executed rollup:off and rollup:on tests, whereas release.yml executed only rollup:on tests -> on purpose?