### PR TITLE
Improper use of Intersection Type

### DIFF
--- a/apis/csn.d.ts
+++ b/apis/csn.d.ts
@@ -43,7 +43,7 @@ export type FQN = string
 /**
  * Definitions are the central elements of a CDS model.
  */
-export type Definition = context & service & type & struct & entity & Association
+export type Definition = context | service | type | struct | entity | Association
 // NOTE: If we use & instead of | CSN.definitions values would be reduced to <never>
 
 /**


### PR DESCRIPTION
See https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html#intersection-types. This is only on occurrence as an example, the pattern repeats in many places in the type definitions

Using `&` might be convenient while defining types, but leads to ugly situations when using theses types. With Union Types(`|`) TypeScript would correctly infer the actual type by using a simple `if` that checks for a specific property or by using a type guard. But like in the given example, everything is merged together and there is no way to differentiate between a `entity` or `context` etc. Which is forcing the consumer to do a type cast. The existing `NOTE` is actually correct, in many situations we end up with `never` which is not really helpful

In other place there is code like `string & { id:string, ...}`. I think the intend is not to say that it is a string with additional properties, most of the time it means OR. So using `if(typeof myVar === "string"){...}` would do the job for a union type. In the if block TypeScript would then treat `myVar` only as string and the further implementation would be pretty clean.

I would like to use this PR as a starting point for the discussion, doing the actual change might have a bigger impact.