### PR TITLE
Fix default export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Added `doc?: string` to `cds.linked.classes.any_`
 
 ### Changed
+- [breaking] Corrected the way the default export is generated. This also gets rid of the export `default_2` that was mistakenly exposed before.
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/apis/cds.d.ts
+++ b/apis/cds.d.ts
@@ -4,4 +4,5 @@
 //  export * as default ...    ^      ^
 //                                    ^ export * from ...
 export * from './facade'
-export * as default from './facade'
+import * as cds from './facade' // have to import and re-export, or rollup will fumble the default export
+export default cds

--- a/test/typescript/apis/project/cds-services.ts
+++ b/test/typescript/apis/project/cds-services.ts
@@ -388,11 +388,11 @@ cds.on('bootstrap', (app): void => {
 
 // cds.context.http
 if (cds.context?.http) {
-  const { req , res } = cds.context.http
+  const { req , res } = cds.context!.http
   if (!req.headers.authentication)
     res.status(403).send('Please login')
   if (!req.is('application/json')) res.send(415)
-  req.headers['x-correlation-id'] = cds.context.id
+  req.headers['x-correlation-id'] = cds.context!.id
 }
 const req3 = cds.context?.http?.req
 
@@ -406,7 +406,7 @@ if (myUser instanceof cds.User) {
 cds.context = { tenant:'t1', user: new cds.User('u2'), locale: 'en_GB', id: 'aaaa', timestamp: new Date(), model: ctx!.model }
 const tx3 = cds.tx (cds.context)
 const db = await cds.connect.to('db')
-cds.context.features = {foo: true}
+cds.context!.features = {foo: true}
 
 cds.tx({tenant: 'myTenant'}, async (tx) => { // tx has to be infered from the type defintion to be a Transaction type
   await tx.run('').then(() => {}, () => {})

--- a/test/typescript/apis/project/cds.ts
+++ b/test/typescript/apis/project/cds.ts
@@ -1,4 +1,5 @@
 import cds from '@sap/cds';
+import * as cdsAll from '@sap/cds';
 
 cds.version === '1.2.3'
 cds.home === 'path/to/cds'
@@ -11,3 +12,9 @@ cds.cli!.command = 'deploy'
 cds.cli!.command = 'unknown-command'
 //@ts-expect-error
 cds.cli!.command = true
+
+// spot test to make sure named and default exports behave similarly
+cds.compile === cdsAll.compile
+cds.middlewares === cdsAll.middlewares
+cds.update === cdsAll.update
+cds.ApplicationService === cdsAll.ApplicationService


### PR DESCRIPTION
Make sure entire facade is actually available as `default` export. The former solution resulted in a synthetic object called "default_2" in the rollup file, which wasn't an actual default export.