### PR TITLE
Add programmatic draft actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Added `cds.linked.LinkedDefinition` as alias for `cds.linked.classes.any_`
 - Added `doc?: string` to `cds.linked.classes.any_`
 - Add overload for `Service.emit` to offer improved type support when using an event type emitted by cds-typer.
+- Added programmatic draft actions.
 
 ### Changed
 - [breaking] Corrected the way the default export is generated. This also gets rid of the export `default_2` that was mistakenly exposed before.

--- a/apis/services.d.ts
+++ b/apis/services.d.ts
@@ -277,7 +277,15 @@ export class Service extends QueryAPI {
 
 }
 
-export class ApplicationService extends Service {}
+export class ApplicationService extends Service {
+  new<T extends Constructable>(draft: T, data: {[K in keyof InstanceType<T>]?: InstanceType<T>[K]}): Promise<unknown>
+  new<T extends Constructable>(draft: T): {
+    for(keys: Key[]): Promise<unknown>,
+  }
+  discard(draft: Constructable, keys: Key[]): Promise<unknown>
+  edit(draft: Constructable, keys: Key[]): Promise<unknown>
+  save(draft: Constructable, keys: Key[]): Promise<unknown>
+}
 export class MessagingService extends Service {}
 export class RemoteService extends Service {}
 export class DatabaseService extends Service {

--- a/test/typescript/apis/project/cds-services.ts
+++ b/test/typescript/apis/project/cds-services.ts
@@ -1,4 +1,4 @@
-import cds, { Service, Request, HandlerFunction } from '@sap/cds'
+import cds, { Service, Request, HandlerFunction, ApplicationService } from '@sap/cds'
 import { Bars, Bar, Foo, Foos, action, as, testType } from './dummy'
 const model = cds.reflect({})
 const { Book: Books } = model.entities
@@ -455,3 +455,12 @@ const msg = await cds.connect.to('CatalogService');
 msg.emit(Foo, { x: 11 })
 msg.emit(Foos, { x: 11, bar: '22' })
 msg.emit(Foos, { x: 11 })
+
+const asrv = srv as ApplicationService
+await asrv.new(Foo.drafts, {x: 42})
+// @ts-expect-error y not a valid property
+await asrv.new(Foo.drafts, {y: 42})
+await asrv.discard(Foo.drafts, [1,2])
+await asrv.edit(Foo, [1,2])
+await asrv.new(Foo.drafts).for([1,2])
+await asrv.save(Foo.drafts, [1,2])


### PR DESCRIPTION
Open questions:
- what is the return type of these actions?
- is the type for `keys` correct?
- are these actions really only available on `ApplicationService`s, as implied in CAPire? Most service-relarted actions before were available for all types of `Service`