### PR TITLE
Make req.reject return never

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 - [breaking] Corrected the way the default export is generated. This also gets rid of the export `default_2` that was mistakenly exposed before.
+- `Request.reject(…)` now returns `never` instead of `Error`, as its implementation always throws.
 
 ### Deprecated
 ### Removed

--- a/apis/events.d.ts
+++ b/apis/events.d.ts
@@ -79,7 +79,7 @@ export class Request<T = any> extends Event<T> {
 
   error (code: number, message: string, target?: string, args?: any[]): Error
 
-  reject (code: number, message: string, target?: string, args?: any[]): Error
+  reject (code: number, message: string, target?: string, args?: any[]): never
 
   notify (code: number, message: string, args?: any[]): Error
 
@@ -89,7 +89,7 @@ export class Request<T = any> extends Event<T> {
 
   error (code: number, message: string, args?: any[]): Error
 
-  reject (code: number, message: string, args?: any[]): Error
+  reject (code: number, message: string, args?: any[]): never
 
   notify (message: string, target?: string, args?: any[]): Error
 
@@ -99,7 +99,7 @@ export class Request<T = any> extends Event<T> {
 
   error (message: string, target?: string, args?: any[]): Error
 
-  reject (message: string, target?: string, args?: any[]): Error
+  reject (message: string, target?: string, args?: any[]): never
 
   notify (message: { code?: number | string, message: string, target?: string, args?: any[] }): Error
 
@@ -109,7 +109,7 @@ export class Request<T = any> extends Event<T> {
 
   error (message: { code?: number | string, message: string, target?: string, args?: any[], status?: number }): Error
 
-  reject (message: { code?: number | string, message: string, target?: string, args?: any[], status?: number }): Error
+  reject (message: { code?: number | string, message: string, target?: string, args?: any[], status?: number }): never
 
 }
 

--- a/test/typescript/apis/project/cds-services.ts
+++ b/test/typescript/apis/project/cds-services.ts
@@ -174,6 +174,7 @@ srv.before('*', async req => {
   // @ts-expect-error  possibly undefined - goes away after req.reject
   thing.toExponential()
   if(!thing) req.reject(1, 'msg', 'target', [])
+  // @ts-expect-error - ts SHOULD infer anything to not be undefined. But for some reason, having a _method_ of :never behaves differently than just a function
   thing.toExponential()
 
   req.error({ code: 'code', status: 404, message: 'message', args: [3,4] })
@@ -460,10 +461,3 @@ const msg = await cds.connect.to('CatalogService');
 msg.emit(Foo, { x: 11 })
 msg.emit(Foos, { x: 11, bar: '22' })
 msg.emit(Foos, { x: 11 })
-
-const anything: undefined | number = 42 as undefined | number
-if (!anything) {
-    new Request({event: ''}).reject(2,'')  
-}
-// @ts-expect-error - ts SHOULD infer anything to not be undefined. But for some reason, having a _method_ of :never behaves differently than just a function
-anything.toExponential()  // anything now known to not be undefined

--- a/test/typescript/apis/project/cds-services.ts
+++ b/test/typescript/apis/project/cds-services.ts
@@ -170,7 +170,11 @@ srv.before('*', async req => {
   req.error(1, 'msg')
   req.notify(1, 'msg', 'target', ['key', 2])
   req.warn(1, 'msg', 'target', [])
-  req.reject(1, 'msg', 'target', [])
+  const thing: number | undefined = 42 as number | undefined
+  if(thing === undefined)
+    req.reject(1, 'msg', 'target', [])
+  thing.toExponential()
+
   req.error({ code: 'code', status: 404, message: 'message', args: [3,4] })
 
   req.id

--- a/test/typescript/apis/project/cds-services.ts
+++ b/test/typescript/apis/project/cds-services.ts
@@ -171,8 +171,9 @@ srv.before('*', async req => {
   req.notify(1, 'msg', 'target', ['key', 2])
   req.warn(1, 'msg', 'target', [])
   const thing: number | undefined = 42 as number | undefined
-  if(thing === undefined)
-    req.reject(1, 'msg', 'target', [])
+  // @ts-expect-error  possibly undefined - goes away after req.reject
+  thing.toExponential()
+  if(!thing) req.reject(1, 'msg', 'target', [])
   thing.toExponential()
 
   req.error({ code: 'code', status: 404, message: 'message', args: [3,4] })
@@ -459,3 +460,10 @@ const msg = await cds.connect.to('CatalogService');
 msg.emit(Foo, { x: 11 })
 msg.emit(Foos, { x: 11, bar: '22' })
 msg.emit(Foos, { x: 11 })
+
+const anything: undefined | number = 42 as undefined | number
+if (!anything) {
+    new Request({event: ''}).reject(2,'')  
+}
+// @ts-expect-error - ts SHOULD infer anything to not be undefined. But for some reason, having a _method_ of :never behaves differently than just a function
+anything.toExponential()  // anything now known to not be undefined


### PR DESCRIPTION
Fixes #442

Make `Request.req` return `never` to [express that it always throws](https://www.typescriptlang.org/play/?#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXzgCtwMAKASgC55UQA3EGAKCdElgTDwGcN4pUATwwALLKgDm1NKETiQweAB8ayALYAjRkyyJ4pAIQDhYyeXgBvJvBsEQxTBSYBfJsdHiJAOgw4AogAeAA54IKjYUBAUNgD0MfxCHpI0OADu8ADWqGn4vil8WvAyIHK0wEA).