### PR TITLE
Remove comment about joins

### DIFF
--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -106,17 +106,6 @@ export class SELECT<T, Q = SELECT_from> extends ConstructedQuery<T> {
   alias (as: string): this
   elements: EntityElements
 
-
-  // Not yet public
-  // fullJoin (other: string, as: string) : this
-  // leftJoin (other: string, as: string) : this
-  // 	rightJoin (other: string, as: string) : this
-  // 	innerJoin (other: string, as: string) : this
-  // 	join (other: string, as: string, kind?: string) : this
-  // on : TaggedTemplateQueryPart<this>
-  //   & ((...expr : string[]) => this)
-  //   & ((predicate:object) => this)
-
   SELECT: CQN.SELECT['SELECT'] & {
     forUpdate?: { wait: number },
     forShareLock?: { wait: number },


### PR DESCRIPTION
Joins will never be part of the API, users should use path expressions instead.