### PR TITLE
Add on.paths to enforce changelog workflow

### DIFF
--- a/.github/workflows/enforce-changelog.yml
+++ b/.github/workflows/enforce-changelog.yml
@@ -3,6 +3,8 @@ name: Enforce Changelog
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    paths:
+      - '**/*.d.ts'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}


### PR DESCRIPTION
Prevents race conditions in dependabot PRs, where the label was sometimes added too late.
Won't happen anymore, as dependabot only touches package.json and package-lock.json.
see for example https://github.com/cap-js/cds-types/pull/453