### PR TITLE
fix(#456): update req.params to consistent type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Optional parameter 'options' in `req.reply`. The object can contain, for example, mimetype and/or filename.
 ### Changed
 - [breaking] Bump dependency to `@sap/cds` to `>=9.0.0`. This means starting with this version, `cds-types` is supposed to be used alongside `@sap/cds@9`!
+- `req.params` always returns an array of objects
 ### Deprecated
 ### Removed
 ### Fixed

--- a/apis/events.d.ts
+++ b/apis/events.d.ts
@@ -51,7 +51,7 @@ export class Event<T = unknown> extends EventContext {
  */
 export class Request<T = any> extends Event<T> {
 
-  params: (string | object)[]
+  params: Record<string, any>[]
 
   method: string
 


### PR DESCRIPTION
Since cds `v9`:
> [req.params](https://cap.cloud.sap/docs/node.js/events#params) now always returns an array of objects.
see https://cap.cloud.sap/docs/releases/may25#changed-structure-of-req-params

Fixes #456