### PR TITLE
Make type for req.subject stricter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 ### Changed
+- `req.subject` now receives stronger typing than just the `ref` type if possible.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/apis/events.d.ts
+++ b/apis/events.d.ts
@@ -1,6 +1,7 @@
 import { Definition, LinkedCSN } from './linked'
 import { Query } from './cqn'
 import { ref } from './cqn'
+import { IsAny } from './internal/util'
 import * as express from 'express'
 
 
@@ -46,6 +47,7 @@ export class Event<T = unknown> extends EventContext {
 
 }
 
+
 /**
  * @see [capire docs](https://cap.cloud.sap/docs/node.js/events)
  */
@@ -67,7 +69,7 @@ export class Request<T = any> extends Event<T> {
 
   query: Query
 
-  subject: ref
+  subject: IsAny<T> extends true ? ref : T
 
   reply (results: any): void
   /** @beta */

--- a/apis/internal/util.d.ts
+++ b/apis/internal/util.d.ts
@@ -34,3 +34,12 @@ type KVPairs<T,K,V> = T extends []
 export type DeepRequired<T> = { 
   [K in keyof T]: DeepRequired<T[K]>
 } & Exclude<Required<T>, null>
+
+
+/**
+ * - `IsAny<any>` -> `true`:  `1 & any` is `any`, so `0 extends any` is `true`.
+ * - `IsAny<anything but any>` -> `false`:
+ * `1 & T` is never `any`, so `0 extends (1 & T)` is `false`.
+ * @internal
+ */
+export type IsAny<T> = 0 extends (1 & T) ? true : false;

--- a/test/typescript/apis/project/cds.events.ts
+++ b/test/typescript/apis/project/cds.events.ts
@@ -1,0 +1,5 @@
+import cds from '@sap/cds'
+import { testType } from './dummy'
+
+testType<any>(new cds.Request({ event: 'Foo' } ).subject)
+testType<number>(new cds.Request<number>({ event: 'Foo' } ).subject)


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-types/issues/463