### PR TITLE
feat:Allow deep partial `INSERT`/`UPDATE`/`UPSERT`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ gen/
 out/
 _out/
 
+# IDE files
+
+.idea/
+
 # API extractor
 
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - Types for alpha task scheduling API
 - Types for `SELECT.pipeline()` and `SELECT.foreach()`
+- Support deep partial `INSERT` / `UPDATE`
+- Add `.byKey(…)` to `SELECT`
 ### Changed
 - `req.subject` now points to the bound entity type when implementing handlers for bound actions.
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Types for alpha task scheduling API
 - Types for `SELECT.pipeline()` and `SELECT.foreach()`
 - Support deep partial `INSERT` / `UPDATE`
-- Add `.byKey(…)` to `SELECT`
 ### Changed
 - `req.subject` now points to the bound entity type when implementing handlers for bound actions.
 ### Deprecated

--- a/apis/internal/query.d.ts
+++ b/apis/internal/query.d.ts
@@ -96,6 +96,14 @@ type Expressions<L,E> = KVPairs<L, Expression<Exclude<keyof E, symbol>>, ColumnV
     ? L
     : never
 
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object
+    ? T[K] extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : DeepPartial<T[K]>
+    : T[K];
+}
+
 type HavingWhere<This, E> = 
   /**
    * @param predicate - An object with keys that are valid fields of the target entity and values that are compared to the respective fields.
@@ -159,8 +167,8 @@ export interface And {
 export interface InUpsert<T> {
   data (block: (e: T) => void): this
 
-  entries (...entries: T[]): this
-  entries (entries: T[]): this
+  entries (...entries: DeepPartial<T>[]): this
+  entries (entries: DeepPartial<T>[]): this
 
   values (...val: (null | Primitive)[]): this
   values (val: (null | Primitive)[]): this

--- a/apis/internal/query.d.ts
+++ b/apis/internal/query.d.ts
@@ -96,13 +96,17 @@ type Expressions<L,E> = KVPairs<L, Expression<Exclude<keyof E, symbol>>, ColumnV
     ? L
     : never
 
-type DeepPartial<T> = {
-  [K in keyof T]?: T[K] extends object
-    ? T[K] extends Array<infer U>
+/**
+ * @beta helper 
+ */
+type DeepPartial<T> = T extends object
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  ? T extends Function
+    ? T
+    : T extends Array<infer U>
       ? Array<DeepPartial<U>>
-      : DeepPartial<T[K]>
-    : T[K];
-}
+      : { [K in keyof T]?: DeepPartial<T[K]> }
+  : T
 
 type HavingWhere<This, E> = 
   /**

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -28,6 +28,7 @@ import {
   Where,
   ByKey,
   InUpsert,
+  DeepPartial,
 } from './internal/query'
 import { _TODO } from './internal/util'
 import { Service } from './services'
@@ -252,7 +253,11 @@ export class DELETE<T> extends ConstructedQuery<T> {
 // operator for qbe expression
 type QbeOp = '=' | '-=' | '+=' | '*=' | '/=' | '%='
 
-export interface UPDATE<T> extends Where<T>, And, ByKey {}
+export interface UPDATE<T> extends Where<T>, And, ByKey {
+  set: UpdateSet<this, T>
+  with: UpdateSet<this, T>
+}
+
 export class UPDATE<T> extends ConstructedQuery<T> {
   private constructor();
 
@@ -263,11 +268,7 @@ export class UPDATE<T> extends ConstructedQuery<T> {
     & ((entity: EntityDescription | ref | Definition, primaryKey?: PK) => UPDATE<StaticAny>)
     & (<T> (entity: T, primaryKey?: PK) => UPDATE<T>)
 
-  set: UpdateSet<this, T>
-  with: UpdateSet<this, T>
-
   UPDATE: CQN.UPDATE['UPDATE']
-
 }
 
 /**
@@ -278,7 +279,7 @@ type UpdateSet<This, T> = TaggedTemplateQueryPart<This>
   // simple value   > title: 'Some Title'
   // qbe expression > stock: { '-=': quantity }
   // cqn expression > descr: {xpr: [{ref:[descr]}, '||', 'Some addition to descr.']}
-  & ((data: {[P in keyof T]?: T[P] | {[op in QbeOp]?: T[P]} | CQN.xpr}) => This)
+  & ((data: {[P in keyof T]?: DeepPartial<T[P]> | {[op in QbeOp]?: DeepPartial<T[P]>} | CQN.xpr}) => This)
 
 export class CREATE<T> extends ConstructedQuery<T> {
   private constructor();

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -208,13 +208,13 @@ export interface INSERT<T> extends Columns<T>, InUpsert<T> {}
 export class INSERT<T> extends ConstructedQuery<T> {
   private constructor();
 
-  static into: (<T extends ArrayConstructable> (entity: T, ...entries: SingularInstanceType<T>[]) => INSERT<SingularInstanceType<T>>)
-    & (<T extends ArrayConstructable> (entity: T, entries?: SingularInstanceType<T>[]) => INSERT<SingularInstanceType<T>>)
+  static into: (<T extends ArrayConstructable> (entity: T, ...entries: DeepPartial<SingularInstanceType<T>>[]) => INSERT<SingularInstanceType<T>>)
+    & (<T extends ArrayConstructable> (entity: T, entries?: DeepPartial<SingularInstanceType<T>>[]) => INSERT<SingularInstanceType<T>>)
     & (TaggedTemplateQueryPart<INSERT<unknown>>)
     & ((entity: EntityDescription, ...entries: Entries[]) => INSERT<StaticAny>)
     & ((entity: EntityDescription, entries?: Entries) => INSERT<StaticAny>)
-    & (<T> (entity: Constructable<T>, ...entries: T[]) => INSERT<T>)
-    & (<T> (entity: Constructable<T>, entries?: T[]) => INSERT<T>)
+    & (<T> (entity: Constructable<T>, ...entries: DeepPartial<T>[]) => INSERT<T>)
+    & (<T> (entity: Constructable<T>, entries?: DeepPartial<T>[]) => INSERT<T>)
 
   from (select: SELECT<T>): this
   INSERT: CQN.INSERT['INSERT']
@@ -226,13 +226,13 @@ export interface UPSERT<T> extends Columns<T>, InUpsert<T> {}
 export class UPSERT<T> extends ConstructedQuery<T> {
   private constructor();
 
-  static into: (<T extends ArrayConstructable> (entity: T, ...entries: SingularInstanceType<T>[]) => UPSERT<SingularInstanceType<T>>)
-    & (<T extends ArrayConstructable> (entity: T, entries?: SingularInstanceType<T>[]) => UPSERT<SingularInstanceType<T>>)
+  static into: (<T extends ArrayConstructable> (entity: T, ...entries: DeepPartial<SingularInstanceType<T>>[]) => UPSERT<SingularInstanceType<T>>)
+    & (<T extends ArrayConstructable> (entity: T, entries?: DeepPartial<SingularInstanceType<T>>[]) => UPSERT<SingularInstanceType<T>>)
     & (TaggedTemplateQueryPart<UPSERT<StaticAny>>)
     & ((entity: EntityDescription, ...entries: Entries[]) => UPSERT<StaticAny>)
     & ((entity: EntityDescription, entries?: Entries) => UPSERT<StaticAny>)
-    & (<T> (entity: Constructable<T>, ...entries: T[]) => UPSERT<T>)
-    & (<T> (entity: Constructable<T>, entries?: T[]) => UPSERT<T>)
+    & (<T> (entity: Constructable<T>, ...entries: DeepPartial<T>[]) => UPSERT<T>)
+    & (<T> (entity: Constructable<T>, entries?: DeepPartial<T>[]) => UPSERT<T>)
 
   UPSERT: CQN.UPSERT['UPSERT']
 

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -79,7 +79,7 @@ export declare class QL<T> {
 
 }
 
-export interface SELECT<T> extends Where<T>, And, ByKey, Having<T>, GroupBy, OrderBy<T>, Limit, Hints {
+export interface SELECT<T> extends Where<T>, And, Having<T>, GroupBy, OrderBy<T>, Limit, Hints {
   // overload specific to SELECT
   columns: Columns<T, this>['columns'] & ((projection: Projection<T>) => this)
 }

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -79,7 +79,7 @@ export declare class QL<T> {
 
 }
 
-export interface SELECT<T> extends Where<T>, And, Having<T>, GroupBy, OrderBy<T>, Limit, Hints {
+export interface SELECT<T> extends Where<T>, And, ByKey, Having<T>, GroupBy, OrderBy<T>, Limit, Hints {
   // overload specific to SELECT
   columns: Columns<T, this>['columns'] & ((projection: Projection<T>) => this)
 }

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -279,7 +279,7 @@ type UpdateSet<This, T> = TaggedTemplateQueryPart<This>
   // simple value   > title: 'Some Title'
   // qbe expression > stock: { '-=': quantity }
   // cqn expression > descr: {xpr: [{ref:[descr]}, '||', 'Some addition to descr.']}
-  & ((data: {[P in keyof T]?: DeepPartial<T[P]> | {[op in QbeOp]?: DeepPartial<T[P]>} | CQN.xpr}) => This)
+  & ((data: {[P in keyof T]?: T[P] | DeepPartial<T[P]> | {[op in QbeOp]?: DeepPartial<T[P]>} | CQN.xpr}) => This)
 
 export class CREATE<T> extends ConstructedQuery<T> {
   private constructor();

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -49,8 +49,6 @@ sel.columns("x")
 // y is not a valid columns for Foo(s),
 // but is allowed anyway since we permit arbitrary strings as well
 SELECT.from(Foos).columns('y')
-SELECT.from(Foos).byKey(42)
-SELECT.from(Foos).byKey({ x: 42 })
 SELECT.from(Foos).where('x=', 42)
 SELECT.from(Foos).where('x >', 42, 'y =', '42')
 const predefinedArray = [42]

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -49,6 +49,8 @@ sel.columns("x")
 // y is not a valid columns for Foo(s),
 // but is allowed anyway since we permit arbitrary strings as well
 SELECT.from(Foos).columns('y')
+SELECT.from(Foos).byKey(42)
+SELECT.from(Foos).byKey({ x: 42 })
 SELECT.from(Foos).where('x=', 42)
 SELECT.from(Foos).where('x >', 42, 'y =', '42')
 const predefinedArray = [42]
@@ -321,10 +323,25 @@ INSERT.into(Foos).entries({ a: "" })
 INSERT.into(Foos).entries([{ a: "" }])
 INSERT.into(Foos).entries({ x: 4, ref: { x: 4 }, refs: [] })
 INSERT.into(Foo).entries({ x: 4 }, { x: 1 }, { x: 4, ref: { x: 1 } })
+INSERT.into(Foo).entries({ ref: {}, refs: [{}] })
+INSERT.into(Foo).entries({ ref: { refs: [{}] }, refs: [{ ref: {} }] })
+INSERT.into(Foo).entries({ ref: {}, refs: [{ x: 1, y: '' }] })
+INSERT.into(Foos).entries({ ref: { refs: [{ x: 1, y: '' }] }, refs: [{}] })
+// @ts-expect-error - invalid type for property 'y' in 'refs'
+INSERT.into(Foo).entries({ ref: {}, refs: [{ x: 1, y: 4 }] })
+// @ts-expect-error - non-existing property 'a' in 'refs'
+INSERT.into(Foo).entries({ ref: {}, refs: [{ x: 1, a: '' }] })
 // @ts-expect-error - invalid type for property x of Foo
 INSERT.into(Foo).entries({ x: "4" })
+
 INSERT.into(Foo, { x: 4, ref: { x: 2 }})
 INSERT.into(Foo, [{ x: 4 }])
+INSERT.into(Foo, { ref: {}, refs: [{ ref: { x: 1 } }] })
+INSERT.into(Foos, { ref: { refs: [{ x: 1 }] }, refs: [{}] })
+// @ts-expect-error - invalid type for property 'y' in 'refs'
+INSERT.into(Foo, { ref: {}, refs: [{ x: 1, y: 4 }] })
+// @ts-expect-error - non-existing property 'a' in 'refs'
+INSERT.into(Foos, { ref: {}, refs: [{ x: 1, a: '' }] })
 
 INSERT.into("Foo", [{ x: "4" }])
 INSERT.into("Foo", { x: "4" }, { "ref": "4" })
@@ -342,8 +359,23 @@ UPSERT.into(Foos).entries({ x: 4, ref: { x: 4 }, refs: [] })
 UPSERT.into(Foo).entries({ x: 4 }, { x: 1 }, { x: 4, ref: { x: 1 } })
 // @ts-expect-error - invalid type for property x of Foo
 UPSERT.into(Foo).entries({ x: "4" })
+UPSERT.into(Foo).entries({ ref: {}, refs: [{}] })
+UPSERT.into(Foo).entries({ ref: { refs: [{}] }, refs: [{ ref: {} }] })
+UPSERT.into(Foo).entries({ ref: {}, refs: [{ x: 1, y: '' }] })
+UPSERT.into(Foos).entries({ ref: { refs: [{ x: 1, y: '' }] }, refs: [{}] })
+// @ts-expect-error - invalid type for property 'y' in 'refs'
+UPSERT.into(Foo).entries({ ref: {}, refs: [{ x: 1, y: 4 }] })
+// @ts-expect-error - non-existing property 'a' in 'refs'
+UPSERT.into(Foo).entries({ ref: {}, refs: [{ x: 1, a: '' }] })
+
 UPSERT.into(Foo, { x: 4, ref: { x: 2 }})
 UPSERT.into(Foo, [{ x: 4 }])
+UPSERT.into(Foo, { ref: {}, refs: [{ ref: { x: 1 } }] })
+UPSERT.into(Foos, { ref: { refs: [{ x: 1 }] }, refs: [{}] })
+// @ts-expect-error - invalid type for property 'y' in 'refs'
+UPSERT.into(Foo, { ref: {}, refs: [{ x: 1, y: 4 }] })
+// @ts-expect-error - non-existing property 'a' in 'refs'
+UPSERT.into(Foos, { ref: {}, refs: [{ x: 1, a: '' }] })
 
 UPSERT.into("Foo", [{ x: "4" }])
 UPSERT.into("Foo", { x: "4" }, { "ref": "4" })
@@ -362,6 +394,22 @@ UPDATE(Foos, 4).set({ aa: 4 });
 UPDATE(Foo).where({ x: 4 }).set({ x: 'asdf', ref: { x: 4 }})
 UPDATE(Foos).where({ x: 4 }).set({ x: 4, ref: { x: 4 }})
 UPDATE.entity(Foos).set({ x: 4});
+
+UPDATE(Foo, 42).set({ ref: {}, refs: [{}] })
+UPDATE(Foo, 42).set({ ref: { refs: [{}] }, refs: [{ ref: {} }] })
+UPDATE(Foo).where({ x: 42 }).with({ ref: {}, refs: [{ x: 1, y: '' }] })
+UPDATE(Foos).where({ x: 42 }).with({ ref: { refs: [{ x: 1, y: '' }] }, refs: [{}] })
+// @ts-expect-error - invalid type for property 'y' in 'refs'
+UPDATE(Foo).set({ ref: {}, refs: [{ x: 1, y: 4 }] })
+// @ts-expect-error - non-existing property 'a' in 'refs'
+UPDATE(Foo).set({ ref: {}, refs: [{ x: 1, a: '' }] })
+
+UPDATE.entity(Foo).set({ ref: {}, refs: [{ ref: { x: 1 } }] })
+UPDATE.entity(Foos).set({ ref: { refs: [{ x: 1 }] }, refs: [{}] })
+// @ts-expect-error - invalid type for property 'y' in 'refs'
+UPDATE(Foo, 42).set({ ref: {}, refs: [{ x: 1, y: 4 }] })
+// @ts-expect-error - non-existing property 'a' in 'refs'
+UPDATE(Foos, 42).set({ ref: {}, refs: [{ x: 1, a: '' }] })
 
 UPDATE.entity(Foos).set({
   x: {'+=': 4 },

--- a/test/typescript/apis/project/dummy.ts
+++ b/test/typescript/apis/project/dummy.ts
@@ -6,8 +6,9 @@
 export class Foo {
     static readonly drafts: typeof Foo
     x: number = 42
-    y?: string
-    ref?: Foo
+    y: string | null = null
+    ref_x: number | null = null
+    ref?: Foo | null
     refs?: Foo[]
   }
 


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-types/issues/461

**TODO:**
- [x] Fix deep partial for `INSERT`, `UPDATE`, `UPSERT`
- [x] ~Add `.byKey(...)` into `SELECT`~ _(as discussed, non-official API to be not exposed)_
- [x] Update `CHANGELOG.md`
- [x] Fix tests
- [x] Add new tests
