### PR TITLE
support SELECT.forUpdate(ignoreLocked)

### DIFF
--- a/apis/cqn.d.ts
+++ b/apis/cqn.d.ts
@@ -19,7 +19,7 @@ export type SELECT = { SELECT: {
   having?: predicate,
   orderBy?: ordering_term[],
   limit?: { rows: val, offset: val },
-  forUpdate?: { wait: number },
+  forUpdate?: { wait: number, ignoreLocked: boolean },
   forShareLock?: { wait: number },
   search?: predicate,
   count?: boolean,

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -101,7 +101,7 @@ export class SELECT<T, Q = SELECT_from> extends ConstructedQuery<T> {
 
   forShareLock (): this
 
-  forUpdate ({ wait }?: { wait?: number }): this
+  forUpdate({ wait, ignoreLocked }?: { wait?: number, ignoreLocked?: boolean }): this
 
   alias (as: string): this
   elements: EntityElements

--- a/test/typescript/apis/project/cds-cqn.ts
+++ b/test/typescript/apis/project/cds-cqn.ts
@@ -27,6 +27,7 @@ res = sqn.SELECT.limit
 res = sqn.SELECT.mixin
 res = sqn.SELECT.forShareLock?.wait
 res = sqn.SELECT.forUpdate?.wait
+res = sqn.SELECT.forUpdate?.ignoreLocked
 res = sqn.SELECT.search?.at(0)
 testType<boolean | undefined>(sqn.SELECT.count)
 

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -275,6 +275,7 @@ DELETE.from `${x}` .where `ID=${x}`
 
 SELECT.from(Foos).forUpdate()
 SELECT.from(Foos).forUpdate({wait: 5})
+SELECT.from(Foos).forUpdate({ignoreLocked: true})
 SELECT.from(Foos).forShareLock()
 
 INSERT.into('Foos').values(1,2,3)


### PR DESCRIPTION
As already described in https://github.com/cap-js/cds-dbs/issues/917, we would like to use the ignorelocked function. This is already implemented and should also be made possible in ts with this pr.