### PR TITLE
feat: result set streaming APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 - Types for alpha task scheduling API
+- Types for `SELECT.pipeline()` and `SELECT.foreach()`
 ### Changed
 - `req.subject` now points to the bound entity type when implementing handlers for bound actions.
 ### Deprecated

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -88,7 +88,7 @@ export interface SELECT<T> extends Where<T>, And, Having<T>, GroupBy, OrderBy<T>
 // as SELECT.one will pass on SELECT_one as Q
 export class SELECT<T, Q = SELECT_from> extends ConstructedQuery<T> {
   private constructor();
-  [Symbol.asyncIterator]<T extends ArrayConstructable>(): AsyncIterableIterator<SingularInstanceType<T>>
+  [Symbol.asyncIterator](): AsyncIterableIterator<Unwrap<T>>
 
   static one: SELECT_one & { from: SELECT_one } & { localized: SELECT_one }
 

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -1,3 +1,4 @@
+import { Readable, Writable } from 'node:stream'
 import { EntityElements } from './csn'
 //export type { Query } from './cqn'
 import * as CQN from './cqn'

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -87,6 +87,7 @@ export interface SELECT<T> extends Where<T>, And, Having<T>, GroupBy, OrderBy<T>
 // as SELECT.one will pass on SELECT_one as Q
 export class SELECT<T, Q = SELECT_from> extends ConstructedQuery<T> {
   private constructor();
+  [Symbol.asyncIterator](): AsyncIterableIterator<SingularInstanceType<T>>
 
   static one: SELECT_one & { from: SELECT_one } & { localized: SELECT_one }
   

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -87,7 +87,7 @@ export interface SELECT<T> extends Where<T>, And, Having<T>, GroupBy, OrderBy<T>
 // as SELECT.one will pass on SELECT_one as Q
 export class SELECT<T, Q = SELECT_from> extends ConstructedQuery<T> {
   private constructor();
-  [Symbol.asyncIterator](): AsyncIterableIterator<SingularInstanceType<T>>
+  [Symbol.asyncIterator]<T extends ArrayConstructable>(): AsyncIterableIterator<SingularInstanceType<T>>
 
   static one: SELECT_one & { from: SELECT_one } & { localized: SELECT_one }
   

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -113,6 +113,32 @@ export class SELECT<T, Q = SELECT_from> extends ConstructedQuery<T> {
     count?: boolean,
   }
 
+  /**
+   * If a parameter is given, the raw data stream is piped into it.
+   *
+   * If no parameter is given, the raw data stream is returned.
+   * @param stream the writable stream to pipe the raw data into 
+   * @see [capire docs](https://cap.cloud.sap/docs/node.js/cds-ql#pipeline)
+   * @since 9.3.0
+   */
+  pipeline(stream: Writable): Promise<void>
+  /**
+   * If a parameter is given, the raw data stream is piped into it.
+   *
+   * If no parameter is given, the raw data stream is returned.
+   * @see [capire docs](https://cap.cloud.sap/docs/node.js/cds-ql#pipeline)
+   * @since 9.3.0
+   * @returns Readable
+   */
+  pipeline(): Promise<Readable>
+
+  /**
+   * Calls the given callback function for each row in the result set.
+   * @param cb the callback function to call for each row
+   * @see [capire docs](https://cap.cloud.sap/docs/node.js/cds-ql#foreach)
+   * @since 9.3.0
+   */
+  foreach<T extends ArrayConstructable>(cb: (element: SingularInstanceType<T>) => void ): Promise<void>
 }
 
 

--- a/apis/ql.d.ts
+++ b/apis/ql.d.ts
@@ -2,11 +2,12 @@ import { Readable, Writable } from 'node:stream'
 import { EntityElements } from './csn'
 //export type { Query } from './cqn'
 import * as CQN from './cqn'
-import { 
+import {
   Constructable,
   ArrayConstructable,
   SingularInstanceType,
-  PluralInstanceType
+  PluralInstanceType,
+  Unwrap
 } from './internal/inference'
 import { Definition } from './linked'
 import { ref } from './cqn'
@@ -90,9 +91,9 @@ export class SELECT<T, Q = SELECT_from> extends ConstructedQuery<T> {
   [Symbol.asyncIterator]<T extends ArrayConstructable>(): AsyncIterableIterator<SingularInstanceType<T>>
 
   static one: SELECT_one & { from: SELECT_one } & { localized: SELECT_one }
-  
+
   static distinct: typeof SELECT<StaticAny>
-  
+
   static from: SELECT_from & { localized: SELECT_from }
 
   static localized: SELECT_from & { from: SELECT_from }
@@ -119,7 +120,7 @@ export class SELECT<T, Q = SELECT_from> extends ConstructedQuery<T> {
    * If a parameter is given, the raw data stream is piped into it.
    *
    * If no parameter is given, the raw data stream is returned.
-   * @param stream the writable stream to pipe the raw data into 
+   * @param stream the writable stream to pipe the raw data into
    * @see [capire docs](https://cap.cloud.sap/docs/node.js/cds-ql#pipeline)
    * @since 9.3.0
    */
@@ -140,9 +141,8 @@ export class SELECT<T, Q = SELECT_from> extends ConstructedQuery<T> {
    * @see [capire docs](https://cap.cloud.sap/docs/node.js/cds-ql#foreach)
    * @since 9.3.0
    */
-  foreach<T extends ArrayConstructable>(cb: (element: SingularInstanceType<T>) => void ): Promise<void>
+  foreach: (cb: (element: Unwrap<T>) => void) => Promise<void>
 }
-
 
 type SELECT_one =
   TaggedTemplateQueryPart<Awaitable<SELECT<_TODO, SELECT_one>, InstanceType<_TODO>>>
@@ -219,7 +219,7 @@ export class INSERT<T> extends ConstructedQuery<T> {
   INSERT: CQN.INSERT['INSERT']
 
 }
-type Entries<T = any> = {[key:string]: T} | {[key:string]: T} 
+type Entries<T = any> = {[key:string]: T} | {[key:string]: T}
 
 export interface UPSERT<T> extends Columns<T>, InUpsert<T> {}
 export class UPSERT<T> extends ConstructedQuery<T> {
@@ -265,7 +265,7 @@ export class UPDATE<T> extends ConstructedQuery<T> {
 
   set: UpdateSet<this, T>
   with: UpdateSet<this, T>
-  
+
   UPDATE: CQN.UPDATE['UPDATE']
 
 }
@@ -276,7 +276,7 @@ export class UPDATE<T> extends ConstructedQuery<T> {
  */
 type UpdateSet<This, T> = TaggedTemplateQueryPart<This>
   // simple value   > title: 'Some Title'
-  // qbe expression > stock: { '-=': quantity }  
+  // qbe expression > stock: { '-=': quantity }
   // cqn expression > descr: {xpr: [{ref:[descr]}, '||', 'Some addition to descr.']}
   & ((data: {[P in keyof T]?: T[P] | {[op in QbeOp]?: T[P]} | CQN.xpr}) => This)
 
@@ -291,7 +291,7 @@ export class CREATE<T> extends ConstructedQuery<T> {
 
 export class DROP<T> extends ConstructedQuery<T> {
   private constructor();
-  
+
   static entity (entity: EntityDescription): DROP<EntityDescription>
 
   DROP: CQN.DROP['DROP']

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -6,6 +6,7 @@ import { Foo, Foos, attach, testType } from './dummy'
 import { connect } from '../../../../apis/server';
 import { expr, ref, val } from '../../../../apis/cqn';
 import * as assert from 'node:assert/strict';
+import { Readable } from 'node:stream';
 
 
 // @ts-expect-error - only supposed to be used statically, constructors private
@@ -261,6 +262,18 @@ SELECT.one.from(Foos).columns([{ ref: ['entityIDColumn'] }]).then(r => r?.ref)
 // @ts-expect-error invalid key of result
 SELECT.one.from(Foos).columns({ ref: ['entityIDColumn'] }).then(r => r?.some)
 SELECT.one.from(Foos).columns({ ref: ['entityIDColumn'] }).then(r => r?.ref)
+
+// SELECT.pipeline()
+await SELECT.from(Foos).pipeline(cds.context!.http!.res)
+const readable = await SELECT.from(Foos).pipeline()
+readable.pipe
+
+// SELECT.foreach()
+await SELECT.from(Foos).foreach(foo => { testType<number>(foo.x)  }) // double check typeof x
+
+// async iterator
+for await (const foo of SELECT.from(Foos)) { foo.x }
+
 
 INSERT.into(Foos).values([1,2,3])
 

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -274,8 +274,8 @@ await SELECT.from(Foo).foreach(foo => { testType<number>(foo.x)  })
 
 
 // async iterator
-for await (const foo of SELECT.from(Foos)) { testType<number>(foo.x) } // double check typeof x
-
+for await (const foo of SELECT.from(Foos)) { testType<number>(foo.x) }
+for await (const foo of SELECT.from(Foo)) { testType<number>(foo.x) }
 
 INSERT.into(Foos).values([1,2,3])
 

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -272,7 +272,7 @@ readable.pipe
 await SELECT.from(Foos).foreach(foo => { testType<number>(foo.x)  }) // double check typeof x
 
 // async iterator
-for await (const foo of SELECT.from(Foos)) { foo.x }
+for await (const foo of SELECT.from(Foos)) { testType<number>(foo.x) } // double check typeof x
 
 
 INSERT.into(Foos).values([1,2,3])

--- a/test/typescript/apis/project/cds-ql.ts
+++ b/test/typescript/apis/project/cds-ql.ts
@@ -20,7 +20,7 @@ new UPSERT;
 // @ts-expect-error
 new DELETE;
 // @ts-expect-error
-new CREATE; 
+new CREATE;
 // @ts-expect-error
 new DROP;
 
@@ -70,7 +70,7 @@ SELECT.from(Foos).hints('x')
 SELECT.from(Foos).hints('x', 'y')
 SELECT.from(Foos).hints(['x', 'y'])
 
-SELECT.from(Foos, f => { 
+SELECT.from(Foos, f => {
     f.x,
     // @ts-expect-error - foobar is not a valid column
     f.foobar
@@ -266,10 +266,12 @@ SELECT.one.from(Foos).columns({ ref: ['entityIDColumn'] }).then(r => r?.ref)
 // SELECT.pipeline()
 await SELECT.from(Foos).pipeline(cds.context!.http!.res)
 const readable = await SELECT.from(Foos).pipeline()
-readable.pipe
+testType<boolean>(readable.readable)
 
 // SELECT.foreach()
-await SELECT.from(Foos).foreach(foo => { testType<number>(foo.x)  }) // double check typeof x
+await SELECT.from(Foos).foreach(foo => { testType<number>(foo.x)  })
+await SELECT.from(Foo).foreach(foo => { testType<number>(foo.x)  })
+
 
 // async iterator
 for await (const foo of SELECT.from(Foos)) { testType<number>(foo.x) } // double check typeof x


### PR DESCRIPTION
will be available with cds9.3

- [x] types for `SELECT.pipeline()`
- [x] types for `SELECT.foreach()`
- [x] types for `for await (x of SELECT)`

I decided against the foreach callback variant in combination with `SELECT.one` since it doesn't make sense to loop through an entry with one value.