### PR TITLE
feat:Extend types for service.dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Support deep partial `INSERT` / `UPDATE`
 ### Changed
 - `req.subject` now points to the bound entity type when implementing handlers for bound actions.
+- `service.dispatch` now also supports passing request objects, or arrays thereof.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/apis/services.d.ts
+++ b/apis/services.d.ts
@@ -253,7 +253,7 @@ export class Service extends QueryAPI {
   }
 
   // The central method to dispatch events
-  dispatch (msg: types.event): Promise<any>
+  dispatch (msg: types.event | Request | types.event[] | Request[]): Promise<any>
 
   // FIXME: not yet documented, will come in future version
   // disconnect (tenant?: string): Promise<void>

--- a/test/typescript/apis/project/cds-services.ts
+++ b/test/typescript/apis/project/cds-services.ts
@@ -493,3 +493,10 @@ await asrv.discard(Foo.drafts, [1,2])
 await asrv.edit(Foo, [1,2])
 await asrv.new(Foo.drafts).for([1,2])
 await asrv.save(Foo.drafts, [1,2])
+
+asrv.on('', (req) => {
+  asrv.dispatch(req)
+  asrv.dispatch([req])
+})
+asrv.dispatch('foo')
+asrv.dispatch(['foo', 'bar'])


### PR DESCRIPTION
Fixes https://github.com/cap-js/cds-types/issues/485