### PR TITLE
fix: positional args vs single object arg

### DIFF
--- a/apis/events.d.ts
+++ b/apis/events.d.ts
@@ -78,29 +78,19 @@ export class Request<
 
   // positional args
   notify (message: string, target?: string, args?: any[]): Error
-  notify (code: string, target?: string, args?: any[]): Error
   notify (status: number, message?: string, target?: string, args?: any[]): Error
-  notify (status: number, code?: string, target?: string, args?: any[]): Error
 
   info (message: string, target?: string, args?: any[]): Error
-  info (code: string, target?: string, args?: any[]): Error
   info (status: number, message?: string, target?: string, args?: any[]): Error
-  info (status: number, code?: string, target?: string, args?: any[]): Error
 
   warn (message: string, target?: string, args?: any[]): Error
-  warn (code: string, target?: string, args?: any[]): Error
   warn (status: number, message?: string, target?: string, args?: any[]): Error
-  warn (status: number, code?: string, target?: string, args?: any[]): Error
 
   error (message: string, target?: string, args?: any[]): Error
-  error (code: string, target?: string, args?: any[]): Error
   error (status: number, message?: string, target?: string, args?: any[]): Error
-  error (status: number, code?: string, target?: string, args?: any[]): Error
 
   reject (message: string, target?: string, args?: any[]): never
-  reject (code: string, target?: string, args?: any[]): never
   reject (status: number, message?: string, target?: string, args?: any[]): never
-  reject (status: number, code?: string, target?: string, args?: any[]): never
 
   // single object arg
   notify (message: { status?: number, code?: number | string, message: string, target?: string, args?: any[] }): Error

--- a/apis/events.d.ts
+++ b/apis/events.d.ts
@@ -76,36 +76,33 @@ export class Request<
   /** @beta */
   reply (results: any, options: { mimetype?: string, filename?: string, [key: string]: any }): void
 
-  notify (status: number, message: string, target?: string, args?: any[]): Error
-
-  info (status: number, message: string, target?: string, args?: any[]): Error
-
-  warn (status: number, message: string, target?: string, args?: any[]): Error
-
-  error (status: number, message: string, target?: string, args?: any[]): Error
-
-  reject (status: number, message: string, target?: string, args?: any[]): never
-
-  notify (status: number, message: string, args?: any[]): Error
-
-  info (status: number, message: string, args?: any[]): Error
-
-  warn (status: number, message: string, args?: any[]): Error
-
-  error (status: number, message: string, args?: any[]): Error
-
-  reject (status: number, message: string, args?: any[]): never
-
+  // positional args
   notify (message: string, target?: string, args?: any[]): Error
+  notify (code: string, target?: string, args?: any[]): Error
+  notify (status: number, message?: string, target?: string, args?: any[]): Error
+  notify (status: number, code?: string, target?: string, args?: any[]): Error
 
   info (message: string, target?: string, args?: any[]): Error
+  info (code: string, target?: string, args?: any[]): Error
+  info (status: number, message?: string, target?: string, args?: any[]): Error
+  info (status: number, code?: string, target?: string, args?: any[]): Error
 
   warn (message: string, target?: string, args?: any[]): Error
+  warn (code: string, target?: string, args?: any[]): Error
+  warn (status: number, message?: string, target?: string, args?: any[]): Error
+  warn (status: number, code?: string, target?: string, args?: any[]): Error
 
   error (message: string, target?: string, args?: any[]): Error
+  error (code: string, target?: string, args?: any[]): Error
+  error (status: number, message?: string, target?: string, args?: any[]): Error
+  error (status: number, code?: string, target?: string, args?: any[]): Error
 
   reject (message: string, target?: string, args?: any[]): never
+  reject (code: string, target?: string, args?: any[]): never
+  reject (status: number, message?: string, target?: string, args?: any[]): never
+  reject (status: number, code?: string, target?: string, args?: any[]): never
 
+  // single object arg
   notify (message: { status?: number, code?: number | string, message: string, target?: string, args?: any[] }): Error
   notify (message: { status?: number, code: number | string, message?: string, target?: string, args?: any[] }): Error
 


### PR DESCRIPTION
pr to add to https://github.com/cap-js/cds-types/pull/500

~i tried to type that it's either `message` or `code` in the positional args style~