### PR TITLE
chore: allow cds-test 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     }
   },
   "devDependencies": {
-    "@cap-js/cds-test": "^0",
+    "@cap-js/cds-test": "^0 || ^1",
     "@cap-js/db-service": "^2.3.0",
     "@microsoft/api-extractor": "^7.52.8",
     "@sap/cds-dk": "^9",


### PR DESCRIPTION
# Chore: Allow `cds-test` Version 1.0.0

### Chore

🔧 Updated the peer dependency range for `@cap-js/cds-test` to support both the `0.x` and the new `1.x` major versions.

### Changes

* `package.json`: Expanded the `@cap-js/cds-test` devDependency version range from `^0` to `^0 || ^1` to allow compatibility with the newly released `1.0.0` version.

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.19.3` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- Correlation ID: `f5f976f0-292d-11f1-9454-27a0a0f79e38`
</details>
