### PR TITLE
fix: Make `cds.context.locale` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Changed
 - `ResultHandler` now returns `unknown` instead of `void`, to accommodate asynchronous functions when having `@typescript-eslint/strict-void-return` activated
 - Documentation for `cds.test.axios` mentioning that `@cap-js/cds-test@1` now returns an `axios` facade in absence of `axios`.
+- made `cds.context.locale` optional
 
 ### Deprecated
 - `cds.test.chai`, `cds.test.assert` pointing to either `cds.test.expect` or a custom import of `chai`.

--- a/apis/events.d.ts
+++ b/apis/events.d.ts
@@ -21,7 +21,7 @@ export class EventContext {
   id: string
 
   /**
-   * ISO 639-1 language code, optionally followed by a underscore and ISO 3166-1 alpha-2 country code, e.g. "en" or "en_US".
+   * ISO 639-1 language code, optionally followed by an underscore and ISO 3166-1 alpha-2 country code, e.g. "en" or "en_US".
    * May be `undefined` if the `AcceptLanguage` header is not set in the incoming request.
    */
   locale?: string

--- a/apis/events.d.ts
+++ b/apis/events.d.ts
@@ -20,7 +20,11 @@ export class EventContext {
 
   id: string
 
-  locale: `${string}_${string}`
+  /**
+   * ISO 639-1 language code, optionally followed by a underscore and ISO 3166-1 alpha-2 country code, e.g. "en" or "en_US".
+   * May be `undefined` if the `AcceptLanguage` header is not set in the incoming request.
+   */
+  locale?: string
 
   timestamp: Date
 


### PR DESCRIPTION
Fixes internal issue 20216