### PR TITLE
Improve CI/CD security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
   versioning-strategy: increase-if-necessary
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 1
   groups:
     production-dependencies:
       dependency-type: "production"
@@ -15,3 +17,10 @@ updates:
     - dependency-name: "chai"
         # chai 5 doesn't work atm w/ cds.test
       versions: ["5.x"]
+
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  cooldown:
+    default-days: 1

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -16,6 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v2

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -35,6 +35,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@v2
+      with:
+        egress-policy: audit
     - uses: actions/checkout@v6
 
     - uses: actions/setup-node@v6

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,11 +17,19 @@ jobs:
   enforce-changelog:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Check changelog
         uses: cap-js/.github/.github/actions/check-changelog@main
 
   check-pr-title:
      runs-on: ubuntu-latest
      steps:
+       - name: Harden Runner
+         uses: step-security/harden-runner@v2
+         with:
+           egress-policy: audit
        - name: Check PR title
          uses: cap-js/.github/.github/actions/check-pr-title@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@v2
+      with:
+        egress-policy: audit
     - uses: actions/checkout@v6
 
     - uses: actions/setup-node@v6


### PR DESCRIPTION
Add dependabot for NPM and GitHub Actions. Weekly checks with 1 day cooldown to avoid pushing freshly compromised deps.

Add [Harden Runner](https://github.com/step-security/harden-runner) to all GitHub Actions to monitor the processes.