### PR TITLE
chore: open dependencies to CDS 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@sap/cds": ">=9.0.0",
-    "@sap/cds-dk": ">=10",
+    "@sap/cds-dk": ">=9",
     "@types/express": ">=4"
   },
   "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@sap/cds": ">=9.0.0",
-    "@sap/cds-dk": "^9",
+    "@sap/cds-dk": ">=10",
     "@types/express": ">=4"
   },
   "peerDependenciesMeta": {
@@ -51,9 +51,9 @@
   },
   "devDependencies": {
     "@cap-js/cds-test": "^0 || ^1",
-    "@cap-js/db-service": "^2.3.0",
+    "@cap-js/db-service": "^2.3.0 || ^3",
     "@microsoft/api-extractor": "^7.52.8",
-    "@sap/cds-dk": "^9",
+    "@sap/cds-dk": "^9 || ^10",
     "@stylistic/eslint-plugin-js": "^4.0.1",
     "@stylistic/eslint-plugin-ts": "^4.0.1",
     "@types/chai": "^5.2.3",


### PR DESCRIPTION
# Open Dependencies to CDS 10

### Chore

🔧 Updated peer and dev dependency version ranges to support `@sap/cds-dk` version 10 and `@cap-js/db-service` version 3.

### Changes

* `package.json`:
  - Updated `peerDependencies`: changed `@sap/cds-dk` from `^9` to `>=10` to align with the existing `@sap/cds` open range.
  - Updated `devDependencies`: expanded `@sap/cds-dk` from `^9` to `^9 || ^10` and `@cap-js/db-service` from `^2.3.0` to `^2.3.0 || ^3` to allow testing against the new major versions.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.1`

- Correlation ID: `243cfeb3-6b5f-484d-85bd-888cab1ff7ba`
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
