### PR TITLE
chore: Add 'new' label to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,7 +1,7 @@
 name: 🐞 Bug
 description: File a bug/issue
 title: "[BUG] <title>"
-labels: ["bug"]
+labels: ["bug", "new"]
 body:
 - type: checkboxes
   attributes:
@@ -34,7 +34,7 @@ body:
   attributes:
     label: Versions
     description: |
-      Run `cds v -i` in your project and copy the output here. 
+      Run `cds v -i` in your project and copy the output here.
       Also include a link to the branch in your GitHub repo.
   validations:
     required: true


### PR DESCRIPTION
Opening an issue through the issue template now also attaches the `new` label. That label is a marker for our issue syncer.